### PR TITLE
Fixing python bindings on Mac OS X

### DIFF
--- a/swig/xtract.i
+++ b/swig/xtract.i
@@ -11,11 +11,6 @@
 #include "xtract/libxtract.h"
 %}
 
-/* Ensure filterbank gets freed */
-/** FIX: This doesn't work, or I'm not using properly. For now just add an explicit call to destroy_filterbank() in the target code */
-%newobject create_filterbank; 
-%delobject destroy_filterbank; 
-
 /*
 %typemap(javabase) SWIGTYPE, SWIGTYPE *, SWIGTYPE &, SWIGTYPE [],
     SWIGTYPE (CLASS::*) "SWIG"


### PR DESCRIPTION
Hey all,

It looks like the python bindings are broken on Mac OS X at least because the floatArray function is unavailable, making it impossible to allocate a low-level float array from python. The documentation on [array_class](http://www.swig.org/Doc1.3/Python.html#Python_nn48) has the include, so I'm pretty sure it's necessary.

I also went ahead and removed the %newobject declaration I saw -- the documentation for [newobject](http://www.swig.org/Doc1.3/Library.html#Library_nn11) says it only specifies that the caller owns the returned pointer, which isn't true here. The returned filterbank needs nested pointers in the struct to be free'd, which requires a call to a "destructor" function that C can't do automatically.

Thanks,
Tej
