### PR TITLE
Develop

### DIFF
--- a/src/fft.h
+++ b/src/fft.h
@@ -25,6 +25,7 @@
 #define FFT_H
 
 #ifdef _MSC_VER
+	#define USE_OOURA
 	#ifndef __cplusplus
 		typedef int bool;
 		#define false 0

--- a/src/vector.c
+++ b/src/vector.c
@@ -108,22 +108,30 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
             {
                 ++n;
 #ifdef USE_OOURA
-                marker = &result[M-1];
+                //marker = &result[M-1];
 #endif
             }
 #ifdef USE_OOURA
-            if(n==1 && withDC) /* discard Nyquist */
+			/*
+            if(n==1 && withDC) // discard Nyquist
             {
                 ++n;
             }
-            if(n == M)
-            {
-                XTRACT_SET_FREQUENCY;
-                break;
-            }
-
-            real = fft[n*2];
-            imag = fft[n*2+1];
+			*/
+			// OOURA discards the always 0 imaginary of DC and Nyquists
+			if (n == M && !withDC)
+			{
+				real = fft[1];
+				imag = fft[0];
+			}
+			else if (n == 0 && withDC) {
+				real = fft[0];
+				imag = 0.0;
+			}
+			else {
+				real = fft[n * 2];
+				imag = fft[n * 2 + 1];
+			}
 #else
             real = fft->realp[n];
             imag = fft->realp[n];
@@ -158,22 +166,30 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
             {
                 ++n;
 #ifdef USE_OOURA
-                marker = &result[M-1];
+                //marker = &result[M-1];
 #endif
             }
 #ifdef USE_OOURA
-            if(n==1 && withDC) /* discard Nyquist */
-            {
-                ++n;
-            }
-            if(n == M)
-            {
-                XTRACT_SET_FREQUENCY;
-                break;
-            }
-
-            real = fft[n*2];
-            imag = fft[n*2+1];
+			/*
+			if(n==1 && withDC) // discard Nyquist
+			{
+				++n;
+			}
+			*/
+			// OOURA discards the always 0 imaginary of DC and Nyquists
+			if (n == M && !withDC)
+			{
+				real = fft[1];
+				imag = fft[0];
+			}
+			else if (n == 0 && withDC) {
+				real = fft[0];
+				imag = 0.0;
+			}
+			else {
+				real = fft[n * 2];
+				imag = fft[n * 2 + 1];
+			}
 #else
             real = fft->realp[n];
             imag = fft->realp[n];
@@ -194,22 +210,30 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
             {
                 ++n;
 #ifdef USE_OOURA
-                marker = &result[M-1];
+                //marker = &result[M-1];
 #endif
             }
 #ifdef USE_OOURA
-            if(n==1 && withDC) /* discard Nyquist */
-            {
-                ++n;
-            }
-            if(n == M)
-            {
-                XTRACT_SET_FREQUENCY;
-                break;
-            }
-
-            real = fft[n*2];
-            imag = fft[n*2+1];
+			/*
+			if(n==1 && withDC) // discard Nyquist
+			{
+				++n;
+			}
+			*/
+			// OOURA discards the always 0 imaginary of DC and Nyquists
+			if (n == M && !withDC)
+			{
+				real = fft[1];
+				imag = fft[0];
+			}
+			else if (n == 0 && withDC) {
+				real = fft[0];
+				imag = 0.0;
+			}
+			else {
+				real = fft[n * 2];
+				imag = fft[n * 2 + 1];
+			}
 #else
             real = fft->realp[n];
             imag = fft->realp[n];
@@ -236,17 +260,26 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
                 ++n;
             }
 #ifdef USE_OOURA
-            if(n==1 && withDC) /* discard Nyquist */
-            {
-                ++n;
-            }
-            if(n == M)
-            {
-                break;
-            }
-
-            real = fft[n*2];
-            imag = fft[n*2+1];
+			/*
+			if(n==1 && withDC) // discard Nyquist
+			{
+				++n;
+			}
+			*/
+			// OOURA discards the always 0 imaginary of DC and Nyquists
+			if (n == M && !withDC)
+			{
+				real = fft[1];
+				imag = fft[0];
+			}
+			else if (n == 0 && withDC) {
+				real = fft[0];
+				imag = 0.0;
+			}
+			else {
+				real = fft[n * 2];
+				imag = fft[n * 2 + 1];
+			}
 #else
             real = fft->realp[n];
             imag = fft->realp[n];
@@ -267,22 +300,30 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
             {
                 ++n;
 #ifdef USE_OOURA
-                marker = &result[M-1];
+               //marker = &result[M-1];
 #endif
             }
 #ifdef USE_OOURA
-            if(n==1 && withDC) /* discard Nyquist */
-            {
-                ++n;
-            }
-            if(n == M)
-            {
-                XTRACT_SET_FREQUENCY;
-                break;
-            }
-
-            real = fft[n*2];
-            imag = fft[n*2+1];
+			/*
+			if(n==1 && withDC) // discard Nyquist
+			{
+				++n;
+			}
+			*/
+			// OOURA discards the always 0 imaginary of DC and Nyquists
+			if (n == M && !withDC)
+			{
+				real = fft[1];
+				imag = fft[0];
+			}
+			else if (n == 0 && withDC) {
+				real = fft[0];
+				imag = 0.0;
+			}
+			else {
+				real = fft[n * 2];
+				imag = fft[n * 2 + 1];
+			}
 #else
             real = fft->realp[n];
             imag = fft->realp[n];
@@ -403,8 +444,8 @@ int xtract_mmbses(const double *data, const int N, const void *argv, double *res
 {
     xtract_mel_filter *f;
     int n, filter;
-    double* real = malloc(sizeof(double)*N);
-    double* imag = malloc(sizeof(double)*N);
+    double* real = (double*)malloc(sizeof(double)*N);
+	double* imag = (double*)malloc(sizeof(double)*N);
 
     f = (xtract_mel_filter *)argv;
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -134,7 +134,7 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 			}
 #else
             real = fft->realp[n];
-            imag = fft->realp[n];
+            imag = fft->imagp[n];
 #endif
 
             temp = XTRACT_SQ(real) + XTRACT_SQ(imag);
@@ -192,7 +192,7 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 			}
 #else
             real = fft->realp[n];
-            imag = fft->realp[n];
+            imag = fft->imagp[n];
 #endif
 
             result[m] = (XTRACT_SQ(real) + XTRACT_SQ(imag)) / NxN;
@@ -236,7 +236,7 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 			}
 #else
             real = fft->realp[n];
-            imag = fft->realp[n];
+            imag = fft->imagp[n];
 #endif
 
             if ((temp = XTRACT_SQ(real) + XTRACT_SQ(imag)) >
@@ -282,7 +282,7 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 			}
 #else
             real = fft->realp[n];
-            imag = fft->realp[n];
+            imag = fft->imagp[n];
 #endif
             result[m*2] = real;
             result[m*2+1] = imag;
@@ -325,8 +325,19 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 				imag = fft[n * 2 + 1];
 			}
 #else
-            real = fft->realp[n];
-            imag = fft->realp[n];
+            if (n == M && !withDC)
+            {
+                real = fft->imagp[0];
+                imag = 0.0;
+            }
+            else if (n == 0 && withDC) {
+                real = fft->realp[0];
+                imag = 0.0;
+            }
+            else {
+                real = fft->realp[n];
+                imag = fft->imagp[n];
+            }
 #endif
             *marker = sqrt(XTRACT_SQ(real) + XTRACT_SQ(imag)) / (double)N;
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -122,7 +122,7 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 			if (n == M && !withDC)
 			{
 				real = fft[1];
-				imag = fft[0];
+				imag = 0.0;
 			}
 			else if (n == 0 && withDC) {
 				real = fft[0];
@@ -133,8 +133,19 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 				imag = fft[n * 2 + 1];
 			}
 #else
-            real = fft->realp[n];
-            imag = fft->imagp[n];
+			if (n == M && !withDC)
+			{
+				real = fft->imagp[0];
+				imag = 0.0;
+		}
+			else if (n == 0 && withDC) {
+				real = fft->realp[0];
+				imag = 0.0;
+			}
+			else {
+				real = fft->realp[n];
+				imag = fft->imagp[n];
+			}
 #endif
 
             temp = XTRACT_SQ(real) + XTRACT_SQ(imag);
@@ -180,7 +191,7 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 			if (n == M && !withDC)
 			{
 				real = fft[1];
-				imag = fft[0];
+				imag = 0.0;
 			}
 			else if (n == 0 && withDC) {
 				real = fft[0];
@@ -191,8 +202,19 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 				imag = fft[n * 2 + 1];
 			}
 #else
-            real = fft->realp[n];
-            imag = fft->imagp[n];
+			if (n == M && !withDC)
+			{
+				real = fft->imagp[0];
+				imag = 0.0;
+		}
+			else if (n == 0 && withDC) {
+				real = fft->realp[0];
+				imag = 0.0;
+			}
+			else {
+				real = fft->realp[n];
+				imag = fft->imagp[n];
+			}
 #endif
 
             result[m] = (XTRACT_SQ(real) + XTRACT_SQ(imag)) / NxN;
@@ -224,7 +246,7 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 			if (n == M && !withDC)
 			{
 				real = fft[1];
-				imag = fft[0];
+				imag = 0.0;
 			}
 			else if (n == 0 && withDC) {
 				real = fft[0];
@@ -235,8 +257,19 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 				imag = fft[n * 2 + 1];
 			}
 #else
-            real = fft->realp[n];
-            imag = fft->imagp[n];
+			if (n == M && !withDC)
+			{
+				real = fft->imagp[0];
+				imag = 0.0;
+		}
+			else if (n == 0 && withDC) {
+				real = fft->realp[0];
+				imag = 0.0;
+			}
+			else {
+				real = fft->realp[n];
+				imag = fft->imagp[n];
+			}
 #endif
 
             if ((temp = XTRACT_SQ(real) + XTRACT_SQ(imag)) >
@@ -270,7 +303,7 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 			if (n == M && !withDC)
 			{
 				real = fft[1];
-				imag = fft[0];
+				imag = 0.0;
 			}
 			else if (n == 0 && withDC) {
 				real = fft[0];
@@ -281,8 +314,19 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 				imag = fft[n * 2 + 1];
 			}
 #else
-            real = fft->realp[n];
-            imag = fft->imagp[n];
+			if (n == M && !withDC)
+			{
+				real = fft->imagp[0];
+				imag = 0.0;
+		}
+			else if (n == 0 && withDC) {
+				real = fft->realp[0];
+				imag = 0.0;
+			}
+			else {
+				real = fft->realp[n];
+				imag = fft->imagp[n];
+			}
 #endif
             result[m*2] = real;
             result[m*2+1] = imag;
@@ -314,7 +358,7 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 			if (n == M && !withDC)
 			{
 				real = fft[1];
-				imag = fft[0];
+				imag = 0.0;
 			}
 			else if (n == 0 && withDC) {
 				real = fft[0];


### PR DESCRIPTION
Hi Jamie,

These should fix the FFT issues with OOURA and Accelerate and make the xtract_spectrum output standardised (withDC option correctly flipping whether to include the DC or include the Nyquist).

It also correctly extracts the Nyquist and DC parameters (real only) and when to calculate them.

Tested on Windows (OOURA) and OSX (OOURA and Accelerate) and both work as expected with all memory in xtract_spectrum result being written to.

Plus small fix to xtract_mmbses which caused errors on Windows for malloc.

Nick