### PR TITLE
MSVC compile fixes

### DIFF
--- a/src/c-ringbuf/ringbuf.c
+++ b/src/c-ringbuf/ringbuf.c
@@ -19,9 +19,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/uio.h>
-#include <unistd.h>
-#include <sys/param.h>
 #include <assert.h>
 
 #ifndef MIN

--- a/src/c-ringbuf/ringbuf.h
+++ b/src/c-ringbuf/ringbuf.h
@@ -30,6 +30,10 @@
 #include <sys/types.h>
 #include <stdbool.h>
 
+#ifdef _MSC_VER
+	typedef ptrdiff_t ssize_t;
+#endif
+
 typedef struct ringbuf_t *ringbuf_t;
 
 /*


### PR DESCRIPTION
I just quickly through the libxtract source files into an existing Visual Studio 2015 project and needed to make the following changes for it to compile with MSVC. AFAIK those extra includes aren't necessary? I also noticed [this commit](https://github.com/dhess/c-ringbuf/pull/2) in the author's c-ringbuf repo, looks like they have already removed at least one of them upstream.

The typedef to ptrdiff_t will be necessary if it is expected for those methods to return a negative value for errors.