### PR TITLE
ringbuf.c: add a missing header

### DIFF
--- a/src/c-ringbuf/ringbuf.c
+++ b/src/c-ringbuf/ringbuf.c
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <assert.h>
 


### PR DESCRIPTION
Fix build error: `unistd.h` needed for `read`.