### PR TITLE
fix: critical memory-safety and correctness bugs in three feature functions

### DIFF
--- a/src/helper.c
+++ b/src/helper.c
@@ -92,7 +92,9 @@ int xtract_smoothed(const double *data, const int N, const void *argv, double *r
     double oneminusgain = 1.0 - gain;
     int i;
     
-    // reverse filtering first
+    // reverse filtering first; the final element seeds the recursion
+    result[N - 1] = data[N - 1];
+
     for (i = N - 2; i >= 0; i--)
     {
         result[i] = gain * data[i] + oneminusgain * data[i+1];

--- a/src/vector.c
+++ b/src/vector.c
@@ -1013,8 +1013,8 @@ int xtract_subbands(const double *data, const int N, const void *argv, double *r
     for(n = 0; n < nbands; n++)
     {
 
-        /* Bounds sanity check */
-        if(lower >= N || lower + bw >= N)
+        /* Bounds sanity check: a band may end exactly at N */
+        if(lower >= N || lower + bw > N)
         {
             //   printf("n: %d\n", n);
             result[n] = 0.0;

--- a/src/vector.c
+++ b/src/vector.c
@@ -409,13 +409,15 @@ int xtract_autocorrelation_fft(const double *data, const int N, const void *argv
 {
 
     int n        = 0;
-    int M        = N << 1;
 
 #ifdef USE_OOURA
+    int M        = N << 1;
     double *rfft = NULL;
 #else
     DSPDoubleSplitComplex *fft = NULL;
-    double M_double = 0.0;
+    double dc = 0.0;
+    double nyquist = 0.0;
+    double norm = 0.0;
 #endif
 
 
@@ -423,8 +425,8 @@ int xtract_autocorrelation_fft(const double *data, const int N, const void *argv
     /* Zero pad the input vector */
     rfft = (double *)calloc(M, sizeof(double));
     memcpy(rfft, data, N * sizeof(double));
-    
-    rdft(M, 1, rfft, ooura_data_autocorrelation_fft.ooura_ip, 
+
+    rdft(M, 1, rfft, ooura_data_autocorrelation_fft.ooura_ip,
             ooura_data_autocorrelation_fft.ooura_w);
 
     for(n = 2; n < M; n += 2)
@@ -439,36 +441,53 @@ int xtract_autocorrelation_fft(const double *data, const int N, const void *argv
     rdft(M, -1, rfft, ooura_data_autocorrelation_fft.ooura_ip,
             ooura_data_autocorrelation_fft.ooura_w);
 
+    /* rdft is unnormalised: a forward/inverse round trip scales by M / 2 = N,
+     * and the conventional autocorrelation scaling contributes a further 1 / N,
+     * giving a total divisor of N * N. This matches xtract_autocorrelation. */
+    for(n = 0; n < N; n++)
+        result[n] = rfft[n] / ((double)N * N);
+    free(rfft);
 #else
-    /* vDSP has its own autocorrelation function, but it doesn't fit the 
+    /* vDSP has its own autocorrelation function, but it doesn't fit the
      * LibXtract model, e.g. we can't guarantee it's going to use
      * an FFT for all values of N */
     fft = &vdsp_data_autocorrelation_fft.fft;
-    vDSP_ctozD((DSPDoubleComplex *)data, 2, fft, 1, N);
-    vDSP_fft_zripD(vdsp_data_autocorrelation_fft.setup, fft, 1, 
+
+    /* The setup is for a 2N-point FFT to allow for zero padding. The split
+     * buffers hold N elements each and are reused between calls, so they
+     * must be zeroed before packing the N input samples (N / 2 complex
+     * pairs) into the lower half; the upper half is the zero padding. */
+    memset(fft->realp, 0, N * sizeof(double));
+    memset(fft->imagp, 0, N * sizeof(double));
+    vDSP_ctozD((DSPDoubleComplex *)data, 2, fft, 1, N >> 1);
+    vDSP_fft_zripD(vdsp_data_autocorrelation_fft.setup, fft, 1,
             vdsp_data_autocorrelation_fft.log2N, FFT_FORWARD);
 
-    for(n = 0; n < N; ++n)
+    /* Power spectrum. In the packed real format DC and Nyquist are real
+     * values stored in realp[0] and imagp[0] and must be squared separately. */
+    dc = fft->realp[0];
+    nyquist = fft->imagp[0];
+
+    for(n = 1; n < N; ++n)
     {
         fft->realp[n] = XTRACT_SQ(fft->realp[n]) + XTRACT_SQ(fft->imagp[n]);
         fft->imagp[n] = 0.0;
     }
 
-    vDSP_fft_zripD(vdsp_data_autocorrelation_fft.setup, fft, 1, 
+    fft->realp[0] = XTRACT_SQ(dc);
+    fft->imagp[0] = XTRACT_SQ(nyquist);
+
+    vDSP_fft_zripD(vdsp_data_autocorrelation_fft.setup, fft, 1,
             vdsp_data_autocorrelation_fft.log2N, FFT_INVERSE);
-#endif
 
-    /* Normalisation factor */
-    M = M * N;
-
-#ifdef USE_OOURA
-    for(n = 0; n < N; n++)
-        result[n] = rfft[n] / (double)M;
-    free(rfft);
-#else
-    M_double = (double)M;
-    vDSP_ztocD(fft, 1, (DOUBLE_COMPLEX *)result, 2, N);
-    vDSP_vsdivD(result, 1, &M_double, result, 1, N);
+    /* Unpack the first N time-domain values (N / 2 complex pairs). The
+     * forward transform is scaled by 2 relative to the DFT (4 after
+     * squaring) and the unnormalised inverse contributes a further 2N;
+     * with the conventional 1 / N autocorrelation scaling the total
+     * divisor is 8 * N * N. This matches xtract_autocorrelation. */
+    norm = 8.0 * (double)N * N;
+    vDSP_ztocD(fft, 1, (DOUBLE_COMPLEX *)result, 2, N >> 1);
+    vDSP_vsdivD(result, 1, &norm, result, 1, N);
 #endif
 
     return XTRACT_SUCCESS;

--- a/tests/Make.config
+++ b/tests/Make.config
@@ -5,9 +5,14 @@ LIBRARY :=
 FLAGS := -I../include -std=c++0x
 
 ifeq ($(OS),Windows_NT)
-    LDFLAGS := ../src/libxtract.lib
+    LDDEPS := ../src/libxtract.lib
 else
-    LDFLAGS := ../src/libxtract.a
+    LDDEPS := ../src/libxtract.a
+endif
+
+LDFLAGS := $(LDDEPS)
+
+ifneq ($(OS),Windows_NT)
     ifeq ($(PLATFORM), Darwin)
         LDFLAGS += -framework Accelerate
     endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,6 +24,9 @@ FLAGS ?= -O3
 DEBUG_FLAGS ?= -O0 -g
 # Flags to pass to the linker
 LDFLAGS ?=
+# Link-time prerequisites that are not objects (e.g. static libraries), so
+# the product is relinked when they change
+LDDEPS ?=
 # Type of product to build: "shared" for a shared library, "static" for a static library, empty for standalone
 LIBRARY ?= static
 # Prefix to the path that the "install" target will install into. libs to $(PREFIX)/lib, executables to $(PREFIX)/bin
@@ -78,11 +81,11 @@ endif
 .SUFFIXES:
 .PHONY: debug clean install uninstall
 
-$(OUT): $(OBJ)
+$(OUT): $(OBJ) $(LDDEPS)
 ifeq "$(LIBRARY)" "static"
-	@$(AR) rcs $@ $^
+	@$(AR) rcs $@ $(OBJ)
 else
-	@$(COMPILER) $^ $(LDFLAGS) -o $@
+	@$(COMPILER) $(OBJ) $(LDFLAGS) -o $@
 endif
 
 debug: FLAGS = $(DEBUG_FLAGS)

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -111,6 +111,47 @@ TEST_CASE("xtract_smoothed", "[helper]")
     }
 }
 
+TEST_CASE("xtract_subbands", "[vector]")
+{
+    const int N = 16;
+    double data[16];
+
+    for (int n = 0; n < N; n++)
+        data[n] = 1.0;
+
+    SECTION("last band is computed when linear bands tile the input exactly")
+    {
+        double result[4] = {0};
+        int argv[4];
+
+        argv[0] = XTRACT_MEAN;
+        argv[1] = 4; /* nbands: 4 bands of 4 samples tiling N exactly */
+        argv[2] = XTRACT_LINEAR_SUBBANDS;
+        argv[3] = 0; /* start */
+
+        xtract_subbands(data, N, argv, result);
+
+        for (int i = 0; i < 4; i++)
+            REQUIRE(result[i] == Approx(1.0).epsilon(EPSILON));
+    }
+
+    SECTION("final octave band is computed when it ends at N")
+    {
+        double result[3] = {0};
+        int argv[4];
+
+        argv[0] = XTRACT_MEAN;
+        argv[1] = 3; /* bands [2, 4), [4, 8), [8, 16) */
+        argv[2] = XTRACT_OCTAVE_SUBBANDS;
+        argv[3] = 2; /* start */
+
+        xtract_subbands(data, N, argv, result);
+
+        for (int i = 0; i < 3; i++)
+            REQUIRE(result[i] == Approx(1.0).epsilon(EPSILON));
+    }
+}
+
 TEST_CASE("xtract_amdf", "[vector]")
 {
     double result[4] = {0};

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -52,6 +52,43 @@ TEST_CASE("xtract_autocorrelation", "[vector]")
     }
 }
 
+TEST_CASE("xtract_autocorrelation_fft", "[vector][fft]")
+{
+    const int N = 16;
+
+    /* The input occupies the first half of a larger buffer with garbage in
+     * the adjacent half, so any read past the input corrupts the result.
+     * The result occupies the first half of a larger buffer with canary
+     * values in the adjacent half, so any write past the result is caught. */
+    double padded_input[2 * N];
+    double guarded_result[2 * N];
+    double reference[N];
+
+    for (int n = 0; n < N; n++)
+        padded_input[n] = sin(2.0 * M_PI * n / 8.0);
+    for (int n = N; n < 2 * N; n++)
+        padded_input[n] = 1.0e6;
+
+    for (int n = 0; n < 2 * N; n++)
+        guarded_result[n] = 12345.0;
+
+    xtract_init_fft(N, XTRACT_AUTOCORRELATION_FFT);
+    xtract_autocorrelation(padded_input, N, NULL, reference);
+    xtract_autocorrelation_fft(padded_input, N, NULL, guarded_result);
+
+    SECTION("does not write past the result buffer")
+    {
+        for (int n = N; n < 2 * N; n++)
+            REQUIRE(guarded_result[n] == 12345.0);
+    }
+
+    SECTION("matches time-domain autocorrelation regardless of adjacent input memory")
+    {
+        for (int n = 0; n < N; n++)
+            REQUIRE(guarded_result[n] == Approx(reference[n]).margin(1e-9));
+    }
+}
+
 TEST_CASE("xtract_amdf", "[vector]")
 {
     double result[4] = {0};

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -89,6 +89,28 @@ TEST_CASE("xtract_autocorrelation_fft", "[vector][fft]")
     }
 }
 
+TEST_CASE("xtract_smoothed", "[helper]")
+{
+    const int N = 8;
+    double data[8] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+    double gain = 0.5;
+
+    SECTION("output does not depend on prior result buffer contents")
+    {
+        double result[8];
+
+        /* Smoothing a constant signal must return the same constant in
+         * every element regardless of what the caller's buffer held. */
+        for (int n = 0; n < N; n++)
+            result[n] = 1.0e9;
+
+        xtract_smoothed(data, N, &gain, result);
+
+        for (int n = 0; n < N; n++)
+            REQUIRE(result[n] == Approx(1.0).epsilon(EPSILON));
+    }
+}
+
 TEST_CASE("xtract_amdf", "[vector]")
 {
     double result[4] = {0};


### PR DESCRIPTION
## Summary

Fixes three critical bugs found in a full correctness audit of the feature extraction functions, each verified by a failing test before the fix (one commit per fix, test included).

### xtract_autocorrelation_fft — buffer over-read/over-write and wrong normalisation
- The vDSP path packed N complex pairs (2N doubles) from an N-double input, so it read N doubles past the caller's buffer and used that memory as the "zero padding" — results depended on adjacent heap contents.
- It also unpacked 2N doubles into the N-double result, corrupting caller memory past the buffer (verified with canaries).
- The packed DC/Nyquist pair was squared as a single complex bin, destroying the Nyquist term.
- Both backends disagreed with the time-domain `xtract_autocorrelation`: vDSP by 4x, OOURA by 0.5x. Both are now normalised to match the time-domain function exactly (verified empirically on both backends).

### xtract_smoothed — uninitialised read
The backward pass filled `result[0..N-2]` only; the forward pass then read `result[N-1]` before writing it, so the last output element depended on the caller's uninitialised buffer. The final element now seeds the recursion with `data[N-1]`.

### xtract_subbands — last band silently zeroed
The bounds check rejected `lower + bw == N`, zeroing the final band whenever the subbands tiled the input exactly — the natural configuration for both linear and octave scales.

## Test plan

- New test cases: `xtract_autocorrelation_fft` (canary guard for over-write, garbage-padded input for over-read, equality with time-domain autocorrelation), `xtract_smoothed` (poisoned result buffer), `xtract_subbands` (exact linear tiling and final octave band).
- Each test was confirmed failing against the previous implementation, and passing after the fix.
- Full suite: 478 assertions in 68 test cases pass locally on macOS (vDSP); `vector.c`/`helper.c` additionally compile warning-free with `-DUSE_OOURA`, and the autocorrelation normalisation was verified against the OOURA backend directly.