### PR TITLE
fix: medium-severity correctness bugs in subband centroids, lpcc, and spectrum scaling

### DIFF
--- a/include/xtract/xtract_vector.h
+++ b/include/xtract/xtract_vector.h
@@ -219,7 +219,7 @@ int xtract_lpc(const double *data, const int N, const void *argv, double *result
  * 
  * \param *data: a pointer to the first element in an array of LPC coeffiecients e.g. a pointer to the second half of the array pointed to by *result from xtract_lpc()
  * \param N: the number of LPC coefficients to be considered
- * \param *argv: a pointer to a double representing the order (Q) of the result vector. This must be a whole number. According to Rabiner and Juang the recommended ratio is Q ~ (3/2)N where N is the number of LPC coefficients and Q > N.
+ * \param *argv: a pointer to an int representing the order (Q) of the result vector. Must be greater than 0. According to Rabiner and Juang the recommended ratio is Q ~ (3/2)N where N is the number of LPC coefficients and Q > N.
  * \param *result: a pointer to an array containing the resultant LPCC.
  * 
  * An array of size Q, where Q is given by argv[0] must be allocated, and *result must point to its first element.

--- a/src/vector.c
+++ b/src/vector.c
@@ -57,8 +57,9 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
     unsigned int M = N >> 1;
 #ifdef USE_OOURA
     double *fft = NULL;
-#else 
+#else
     DSPDoubleSplitComplex *fft = NULL;
+    double half = 0.5;
 #endif
 
     q = *(double *)argv;
@@ -94,8 +95,14 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 #else
     fft = &vdsp_data_spectrum.fft;
     vDSP_ctozD((DSPDoubleComplex *)data, 2, fft, 1, N >> 1);
-    vDSP_fft_zripD(vdsp_data_spectrum.setup, fft, 1, 
+    vDSP_fft_zripD(vdsp_data_spectrum.setup, fft, 1,
             vdsp_data_spectrum.log2N, FFT_FORWARD);
+
+    /* The vDSP forward real FFT is scaled by 2 relative to the DFT; halve
+     * it to the canonical DFT convention shared with the OOURA backend so
+     * spectra are identical across platforms */
+    vDSP_vsmulD(fft->realp, 1, &half, fft->realp, 1, M);
+    vDSP_vsmulD(fft->imagp, 1, &half, fft->imagp, 1, M);
 #endif
 
     switch(vector)

--- a/src/vector.c
+++ b/src/vector.c
@@ -647,8 +647,8 @@ int xtract_spectral_subband_centroids(const double *data, const int N, const voi
 {
     xtract_mel_filter *f = (xtract_mel_filter *)argv;
     int n, filter;
-    const double *freqs = data;
-    const double *amps = data+N;
+    const double *amps = data;
+    const double *freqs = data + N;
 
     for (filter = 0; filter < f->n_filters; filter++)
     {
@@ -656,12 +656,12 @@ int xtract_spectral_subband_centroids(const double *data, const int N, const voi
 
         for(n = 0; n < N; n++)
         {
-            double Multiplier = amps[n]*f->filters[filter][n];
+            double weighted_amp = amps[n] * f->filters[filter][n];
 
-            FA += freqs[n]*f->filters[filter][n]*Multiplier;
-            A += Multiplier;
+            FA += freqs[n] * weighted_amp;
+            A += weighted_amp;
         }
-        if (FA == 0.0 || A == 0.0)
+        if (A == 0.0)
             result[filter] = 0;
         else
             result[filter] = FA / A;

--- a/src/vector.c
+++ b/src/vector.c
@@ -961,8 +961,11 @@ int xtract_lpcc(const double *data, const int N, const void *argv, double *resul
     if(argv == NULL)
         cep_length = N - 1; /* FIX: if we're going to have default values, they should come from the descriptor */
     else
+    {
         cep_length = *(int *)argv;
-    //cep_length = (int)((double *)argv)[0];
+        if(cep_length <= 0)
+            return XTRACT_ARGUMENT_ERROR;
+    }
 
     memset(result, 0, cep_length * sizeof(double));
 

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -882,6 +882,16 @@ TEST_CASE("xtract_spectrum MAGNITUDE_SPECTRUM stores scalar magnitudes", "[vecto
         }
     }
 
+    SECTION("unit cosine has canonical magnitude 0.5 at its bin")
+    {
+        /* The DFT of cos(2*pi*k*n/N) has |X[k]| = N/2, so the canonical
+         * magnitude |X[k]| / N is 0.5 regardless of FFT backend. */
+        double argv[] = {sr / N, (double)XTRACT_MAGNITUDE_SPECTRUM, 0.0, 0.0};
+        xtract_spectrum(data, N, argv, result);
+
+        REQUIRE(result[3] == Approx(0.5).margin(1e-9));
+    }
+
     SECTION("normalised magnitude spectrum has max of 1.0")
     {
         double argv[] = {sr / N, (double)XTRACT_MAGNITUDE_SPECTRUM, 0.0, 1.0};

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -152,6 +152,39 @@ TEST_CASE("xtract_subbands", "[vector]")
     }
 }
 
+TEST_CASE("xtract_spectral_subband_centroids", "[vector]")
+{
+    /* Input follows the documented xtract_spectrum() layout:
+     * amplitudes in data[0..N), frequencies in data[N..2N). */
+    const int N = 8;
+    double data[16] = {0};
+    double filter_bank[2][8];
+    double *filter_ptrs[2] = {filter_bank[0], filter_bank[1]};
+    xtract_mel_filter mf;
+    double result[2] = {0};
+
+    /* One partial per band: a band containing a single partial has its
+     * centroid at that partial's frequency. */
+    data[2] = 3.0;
+    data[5] = 2.0;
+    for (int n = 0; n < N; n++)
+        data[N + n] = (n + 1) * 100.0;
+
+    /* Two rectangular filters covering bins [0, 4) and [4, 8) */
+    for (int n = 0; n < N; n++)
+    {
+        filter_bank[0][n] = n < 4 ? 1.0 : 0.0;
+        filter_bank[1][n] = n < 4 ? 0.0 : 1.0;
+    }
+    mf.n_filters = 2;
+    mf.filters = filter_ptrs;
+
+    xtract_spectral_subband_centroids(data, N, &mf, result);
+
+    REQUIRE(result[0] == Approx(300.0).epsilon(EPSILON));
+    REQUIRE(result[1] == Approx(600.0).epsilon(EPSILON));
+}
+
 TEST_CASE("xtract_amdf", "[vector]")
 {
     double result[4] = {0};

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -185,6 +185,32 @@ TEST_CASE("xtract_spectral_subband_centroids", "[vector]")
     REQUIRE(result[1] == Approx(600.0).epsilon(EPSILON));
 }
 
+TEST_CASE("xtract_lpcc", "[vector]")
+{
+    SECTION("rejects a non-positive cepstrum length")
+    {
+        double lpc[3] = {0.0, 0.5, 0.25};
+        double result[4] = {0};
+        int cep_length = 0;
+
+        REQUIRE(xtract_lpcc(lpc, 3, &cep_length, result) == XTRACT_ARGUMENT_ERROR);
+    }
+
+    SECTION("computes the cepstral recursion for an int argv")
+    {
+        /* data[0] is unused (the recursion starts at data[1]):
+         * c[1] = a[1] = 0.5
+         * c[2] = a[2] + (1 * c[1] * a[1]) / 2 = 0.25 + 0.125 = 0.375 */
+        double lpc[3] = {0.0, 0.5, 0.25};
+        double result[2] = {0};
+        int cep_length = 2;
+
+        REQUIRE(xtract_lpcc(lpc, 3, &cep_length, result) == XTRACT_SUCCESS);
+        REQUIRE(result[0] == Approx(0.5).epsilon(EPSILON));
+        REQUIRE(result[1] == Approx(0.375).epsilon(EPSILON));
+    }
+}
+
 TEST_CASE("xtract_amdf", "[vector]")
 {
     double result[4] = {0};


### PR DESCRIPTION
## Summary

Three medium-severity fixes from the correctness audit, TDD throughout (each commit contains a test confirmed failing against the previous implementation, plus the fix).

### xtract_spectral_subband_centroids — swapped input layout and inconsistent weighting
The function read frequencies from the first half of the input and amplitudes from the second — the opposite of the documented `xtract_spectrum()` layout — and applied the filter weight twice in the numerator but only once in the denominator. For documented usage the output was meaningless (a single 300 Hz partial in a band produced a "centroid" of 0.9). Now uses the documented layout and weights consistently: a band containing one partial returns exactly that partial's frequency.

### xtract_lpcc — argv type contradiction between header and implementation
The header documented `argv` as a pointer to a double; the implementation and descriptor read an int. Following the header doc passed a value whose low 32 bits are zero, so the function silently wrote nothing. The header now documents the int (matching the descriptor and existing callers), and non-positive cepstrum lengths are rejected with `XTRACT_ARGUMENT_ERROR` instead of reaching `memset`.

### xtract_spectrum — canonical scaling across FFT backends
The vDSP forward real FFT is scaled by 2 relative to the DFT, so every spectrum type on macOS produced values double those of the OOURA backend on Linux/Windows. The canonical convention is now the textbook DFT scaling already produced by OOURA (magnitude = |X[k]| / N): the vDSP transform output is halved, making absolute spectrum values identical across platforms and allowing platform-independent absolute assertions in tests.

**Behaviour change note:** any macOS code depending on the previous 2× absolute spectrum scale will see halved values. Relative/normalised results (centroid, flatness, normalised spectra, MFCCs from log energies up to the DC offset of the log) are unaffected.

### Audit note
A fourth candidate (xtract_rolloff reporting one bin high) was investigated and found **not** to be a bug: the documented input is `xtract_spectrum()` output with DC discarded, under which output bin m corresponds to frequency (m+1)·q — the same convention `xtract_peak_spectrum` applies. The existing rolloff tests already encode this correctly, so no change was made.

## Test plan

- New tests: subband centroids (documented layout, exact expected centroids), lpcc (error path + hand-derived cepstral recursion values), spectrum (canonical absolute magnitude 0.5 for a unit cosine).
- Full suite passes on the vDSP backend (485 assertions, 70 test cases).
- Full suite additionally built and run against the OOURA backend (`-DUSE_OOURA`): identical results, confirming cross-platform agreement after the scaling change.