### PR TITLE
fix: low-severity edge cases across six feature functions

### DIFF
--- a/src/scalar.c
+++ b/src/scalar.c
@@ -865,7 +865,10 @@ int xtract_sharpness(const double *data, const int N, const void *argv, double *
     temp = 0.0;
 
     if(n > XTRACT_BARK_BANDS)
+    {
+        n = XTRACT_BARK_BANDS;
         rv = XTRACT_BAD_VECTOR_SIZE;
+    }
     else
         rv = XTRACT_SUCCESS;
 

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -1314,7 +1314,13 @@ int xtract_midicent(const double *data, const int N, const void *argv, double *r
 {
     double f0 = *(double *)argv;
     double note = 0.0;
-      
+
+    if (f0 <= 0.0)
+    {
+        *result = 0.0;
+        return XTRACT_ARGUMENT_ERROR;
+    }
+
     note = 69 + log(f0 / 440.f) * 17.31234;
     note *= 100;
     note = floor( 0.5f + note ); // replace -> round(note);

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -939,8 +939,11 @@ int xtract_lowest_value(const double *data, const int N, const void *argv, doubl
     }
 
     if (*result == DBL_MAX)
+    {
+        *result = 0.0;
         return XTRACT_NO_RESULT;
-        
+    }
+
     return XTRACT_SUCCESS;
 }
 

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -1021,6 +1021,14 @@ int xtract_hps(const double *data, const int N, const void *argv, double *result
         }
     }
 
+    if (peak == 0.0)
+    {
+        /* Silent spectrum: no harmonic product peak exists, and
+         * data[peak_index] would divide by zero below. */
+        *result = 0;
+        return XTRACT_NO_RESULT;
+    }
+
     largest1_lwr = position1_lwr = 0;
 
     for(i = 0; i < n; ++i)

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -144,12 +144,6 @@ int xtract_skewness(const double *data, const int N, const void *argv,  double *
     const double arg0 = ((double *)argv)[0];
     const double arg1 = ((double *)argv)[1];
 
-    if (((double *)argv)[1] == 0)
-    {
-      *result = 0.0;
-      return XTRACT_NO_RESULT;
-    }
-
     *result = 0.0;
 
     if (arg1 == 0)
@@ -309,12 +303,6 @@ int xtract_spectral_skewness(const double *data, const int N, const void *argv, 
 
     if (arg1 == 0.0)
     {
-        return XTRACT_NO_RESULT;
-    }
-
-    if (((double *)argv)[1] == 0.0)
-    {
-        *result = 0.0;
         return XTRACT_NO_RESULT;
     }
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -692,20 +692,32 @@ int xtract_dct(const double *data, const int N, const void *argv, double *result
         }
         free(dct_cos_table);
         dct_cos_table = NULL;
+        dct_cos_table_dim = 0;
     }
     // Allocate the dct cache table
     if (dct_cos_table == NULL)
     {
-        dct_cos_table_dim = N;
         dct_cos_table = calloc(N, sizeof(double*));
+        if (dct_cos_table == NULL)
+            return XTRACT_MALLOC_FAILED;
         for (n = 0; n < N; ++n)
         {
             dct_cos_table[n] = calloc(N, sizeof(double));
+            if (dct_cos_table[n] == NULL)
+            {
+                // Don't leave a half-built table cached as valid
+                for (m = 0; m < n; ++m)
+                    free(dct_cos_table[m]);
+                free(dct_cos_table);
+                dct_cos_table = NULL;
+                return XTRACT_MALLOC_FAILED;
+            }
             for (m = 1; m <= N; ++m)
             {
                 dct_cos_table[n][m-1] = cos(M_PI * (n / (double)N)*(m - 0.5));
             }
         }
+        dct_cos_table_dim = N;
     }
     // Calculate the dct transformation
     temp_dct_table = dct_cos_table;

--- a/src/vector.c
+++ b/src/vector.c
@@ -882,6 +882,12 @@ int xtract_harmonic_spectrum(const double *data, const int N, const void *argv, 
     f0 = *((double *)argv);
     threshold = *((double *)argv+1);
 
+    if(f0 == 0.0)
+    {
+        memset(result, 0, N * sizeof(double));
+        return XTRACT_NO_RESULT;
+    }
+
     ratio = nearest = distance = 0.0;
 
     while(n--)

--- a/tests/xttest_scalar.cpp
+++ b/tests/xttest_scalar.cpp
@@ -1394,6 +1394,17 @@ TEST_CASE("xtract_lowest_value", "[scalar]")
         xtract_lowest_value(data, 4, &threshold, &result);
         REQUIRE(result == Approx(3.0).epsilon(EPSILON));
     }
+
+    SECTION("no qualifying values gives 0, not DBL_MAX")
+    {
+        /* By library convention *result is 0 when XTRACT_NO_RESULT is
+         * returned. */
+        double data[] = {1.0, 2.0, 3.0};
+        double threshold = 10.0;
+        result = 999.0;
+        REQUIRE(xtract_lowest_value(data, 3, &threshold, &result) == XTRACT_NO_RESULT);
+        REQUIRE(result == 0.0);
+    }
 }
 
 TEST_CASE("xtract_power", "[scalar]")

--- a/tests/xttest_scalar.cpp
+++ b/tests/xttest_scalar.cpp
@@ -1434,6 +1434,22 @@ TEST_CASE("xtract_midicent", "[scalar]")
         xtract_midicent(NULL, 0, &freq, &result);
         REQUIRE(result == Approx(6000.0).margin(1.0)); /* 1 midicent absolute */
     }
+
+    SECTION("zero frequency is rejected")
+    {
+        double freq = 0.0;
+        result = 999.0;
+        REQUIRE(xtract_midicent(NULL, 0, &freq, &result) == XTRACT_ARGUMENT_ERROR);
+        REQUIRE(result == 0.0);
+    }
+
+    SECTION("negative frequency is rejected rather than returning NaN")
+    {
+        double freq = -440.0;
+        result = 999.0;
+        REQUIRE(xtract_midicent(NULL, 0, &freq, &result) == XTRACT_ARGUMENT_ERROR);
+        REQUIRE(result == 0.0);
+    }
 }
 
 /* ===== Spectral Features (using synthetic spectral data) ===== */

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -681,6 +681,21 @@ TEST_CASE("xtract_spectral_kurtosis normalisation", "[scalar][spectral]")
     }
 }
 
+TEST_CASE("xtract_hps silent spectrum", "[scalar][spectral]")
+{
+    SECTION("all-zero spectrum yields no result rather than NaN")
+    {
+        const int N = 256;
+        double data[256] = {0};
+        double result = 999.0;
+
+        int rv = xtract_hps(data, N, NULL, &result);
+
+        REQUIRE(rv == XTRACT_NO_RESULT);
+        REQUIRE(result == 0.0);
+    }
+}
+
 TEST_CASE("xtract_hps N/2 bounds", "[scalar][spectral]")
 {
     SECTION("second loop should not read frequency data as amplitudes")

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -211,6 +211,27 @@ TEST_CASE("xtract_lpcc", "[vector]")
     }
 }
 
+TEST_CASE("xtract_harmonic_spectrum", "[vector]")
+{
+    SECTION("zero fundamental yields no result and a zeroed output")
+    {
+        /* With f0 = 0 no harmonic classification is possible; every bin
+         * must be zeroed rather than passed through as "harmonic". */
+        const int N = 8;
+        double data[8] = {1.0, 2.0, 3.0, 4.0, 100.0, 200.0, 300.0, 400.0};
+        double result[8];
+        double argv[2] = {0.0, 0.2}; /* f0 = 0, threshold = 0.2 */
+
+        for (int n = 0; n < N; n++)
+            result[n] = 999.0;
+
+        REQUIRE(xtract_harmonic_spectrum(data, N, argv, result) == XTRACT_NO_RESULT);
+
+        for (int n = 0; n < N; n++)
+            REQUIRE(result[n] == 0.0);
+    }
+}
+
 TEST_CASE("xtract_amdf", "[vector]")
 {
     double result[4] = {0};

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -627,6 +627,23 @@ TEST_CASE("xtract_sharpness", "[scalar][spectral]")
         REQUIRE(result > 0.0);
         REQUIRE(std::isfinite(result));
     }
+
+    SECTION("bands beyond XTRACT_BARK_BANDS are ignored")
+    {
+        /* The extra bands carry huge values that must not contribute:
+         * both calls then sum the same 26 bands, so the results differ
+         * only by the 1/N divisor. */
+        double data[30];
+        double result26 = 0.0;
+        double result30 = 0.0;
+
+        for (int i = 0; i < 30; i++)
+            data[i] = i < XTRACT_BARK_BANDS ? 1.0 : 1.0e12;
+
+        REQUIRE(xtract_sharpness(data, 30, NULL, &result30) == XTRACT_BAD_VECTOR_SIZE);
+        REQUIRE(xtract_sharpness(data, XTRACT_BARK_BANDS, NULL, &result26) == XTRACT_SUCCESS);
+        REQUIRE(result30 * 30.0 == Approx(result26 * XTRACT_BARK_BANDS).epsilon(1e-10));
+    }
 }
 
 /* ===== Bug-specific tests from REVIEW.md =====


### PR DESCRIPTION
## Summary

Edge-case fixes from the correctness audit, TDD throughout (each fix commit contains a test confirmed failing first, except the allocation fix where OOM is not practically testable).

- **xtract_harmonic_spectrum**: f0 = 0 made the harmonic ratio infinite and the distance NaN; since NaN comparisons are false, every bin was classified harmonic. Now returns `XTRACT_NO_RESULT` with zeroed output, matching the other functions taking a fundamental via argv (tristimulus, odd_even_ratio, spectral_inharmonicity).
- **xtract_midicent**: f0 = 0 returned -inf; negative f0 returned NaN with `XTRACT_SUCCESS` (NaN comparisons bypassed the range check). Non-positive f0 now returns `XTRACT_ARGUMENT_ERROR`, consistent with the function's existing out-of-range convention.
- **xtract_hps**: an all-zero spectrum divided by zero and propagated NaN; now returns `XTRACT_NO_RESULT`.
- **xtract_dct**: cosine-table callocs were unchecked, and a failed row allocation left a half-built table cached as valid; now returns `XTRACT_MALLOC_FAILED` and cleans up.
- **xtract_sharpness**: when N exceeded `XTRACT_BARK_BANDS` the error code was set but the bark-band weighting was still applied to out-of-model indices; now clamps like `xtract_loudness`.
- **xtract_lowest_value**: left its `DBL_MAX` sentinel in `*result` on `XTRACT_NO_RESULT`, contradicting the documented convention that 0 is given; now zeroes the result.
- chore: removed duplicated dead zero-checks in `xtract_skewness` / `xtract_spectral_skewness`.

### Deferred: xtract_mcleod_f0 key-maximum selection
The audit noted the peak picker takes the *first local maximum* above threshold rather than McLeod's per-region key maximum. A numerical sweep (two-sine mixtures, f0 150–400 Hz, ratios 1.04–1.35, amplitudes 0.4–1.0, plus AM and inharmonic cases) found **no signal where the two strategies choose different peaks** at the 0.8 threshold — high NSDF lobes are always separated by negative regions in practice. With no demonstrable failure, restructuring working pitch-detection code would be untestable churn, so this is deferred unless a real-world failing case appears.

## Test plan

- New failing-first tests for the five testable fixes; existing dct tests serve as regression for the allocation fix.
- Full suite passes on both FFT backends: 505 assertions in 72 test cases (vDSP locally, OOURA via a `-DUSE_OOURA` build of the suite).