### PR TITLE
chore: remove stale known-bug tag from spectrum normalisation test

### DIFF
--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -826,7 +826,7 @@ TEST_CASE("xtract_crest divide-by-zero", "[scalar][edge-case]")
     }
 }
 
-TEST_CASE("xtract_spectrum normalisation", "[vector][fft][known-bug]")
+TEST_CASE("xtract_spectrum normalisation", "[vector][fft]")
 {
     SECTION("power spectrum normalisation max bin is 1.0")
     {


### PR DESCRIPTION
The `[known-bug]` tag on the spectrum normalisation test is stale — the test passes and the tagged bug no longer exists. Tag removed so the test reads as a normal regression test.