### PR TITLE
fix: align sharpness and odd/even ratio with their canonical definitions

### DIFF
--- a/include/xtract/xtract_scalar.h
+++ b/include/xtract/xtract_scalar.h
@@ -322,12 +322,19 @@ int xtract_crest(const double *data, const int N, const void *argv, double *resu
 int xtract_power(const double *data, const int N, const void *argv, double *result);
     
 /* Odd to even harmonic ratio */
-/** \brief Extract the Odd to even harmonic ratio of an input vector 
- * 
+/** \brief Extract the Odd to even harmonic ratio of an input vector
+ *
  * \param *data: a pointer to the first element in an array of doubles representing a harmonic spectrum of size N/2, and a frequency spectrum of size N/2 (This is the output format of xtract_harmonic_spectrum())
- * \param N: the number of elements to be considered. 
+ * \param N: the number of elements to be considered.
  * \param *argv: a pointer to a double representing the fundamental frequency of the input vector.
- * \param *result: the even/odd harmonic ratio of N values from the array pointed to by *data
+ * \param *result: the odd/even harmonic ratio of N values from the array pointed to by *data
+ *
+ * Harmonics are numbered from 1 (the fundamental); bins nearest to harmonic
+ * zero (below half the fundamental) contribute to neither sum. The ratio is
+ * computed in whatever unit the coefficients are given: magnitude
+ * coefficients give an amplitude ratio, while coefficients derived from
+ * XTRACT_POWER_SPECTRUM give the odd-to-even harmonic energy ratio of
+ * Peeters (2004).
  */
 int xtract_odd_even_ratio(const double *data, const int N, const void *argv, double *result);
 

--- a/include/xtract/xtract_scalar.h
+++ b/include/xtract/xtract_scalar.h
@@ -331,12 +331,17 @@ int xtract_power(const double *data, const int N, const void *argv, double *resu
  */
 int xtract_odd_even_ratio(const double *data, const int N, const void *argv, double *result);
 
-/** \brief Extract the Sharpness of an input vector 
- * 
- * \param *data: a pointer to the first element in an array of doubles representing the magnitude coefficients from the spectrum of an audio vector, (e.g. the first half of the array pointed to by *result from xtract_spectrum().
- * \param N: the number of elements to be considered
+/** \brief Extract the Sharpness of an input vector
+ *
+ * \param *data: a pointer to the first element in an array of doubles representing Bark band coefficients (e.g. the result of xtract_bark_coefficients())
+ * \param N: the number of Bark bands to be considered
  * \param *argv: a pointer to NULL
- * \param *result: the Sharpness of N values from the array pointed to by *data
+ * \param *result: the sharpness of the input, in acums
+ *
+ * Perceptual sharpness after von Bismarck (1974), in the formulation given
+ * by Peeters (2004) with band weighting g(z) per Fastl and Zwicker: the
+ * g-weighted centroid of specific loudness normalised by total loudness,
+ * where the specific loudness of Bark band z is N'(z) = E(z)^0.23.
  */
 int xtract_sharpness(const double *data, const int N, const void *argv, double *result);
 

--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -390,7 +390,8 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
         case XTRACT_TRISTIMULUS_2:
         case XTRACT_TRISTIMULUS_3:
         case XTRACT_ODD_EVEN_RATIO:
-            *data_format = XTRACT_SPECTRAL_HARMONICS_MAGNITUDES;
+            /* These read N/2 amplitudes followed by N/2 frequencies */
+            *data_format = XTRACT_SPECTRAL_HARMONICS;
             break;
         case XTRACT_LOUDNESS:
         case XTRACT_SHARPNESS:
@@ -479,10 +480,8 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
         case XTRACT_SPECTRAL_SLOPE:
         case XTRACT_HARMONIC_SPECTRUM:
         case XTRACT_SPECTRAL_INHARMONICITY:
-            *data_unit = XTRACT_ANY_AMPLITUDE_HERTZ;
-            break;
         case XTRACT_ODD_EVEN_RATIO:
-            *data_unit = XTRACT_HERTZ;
+            *data_unit = XTRACT_ANY_AMPLITUDE_HERTZ;
             break;
         }
 

--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -927,7 +927,8 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
             strcpy(desc, "Extract the spectral sharpness of a spectrum");
             strcpy(p_desc,
                    "Extract the spectral sharpness of an audio spectrum");
-            strcpy(author, "");
+            strcpy(author, "von Bismarck");
+            *year = 1974;
             break;
         case XTRACT_SPECTRAL_SLOPE:
             strcpy(name, "spectral_slope");

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -845,12 +845,13 @@ int xtract_odd_even_ratio(const double *data, const int N, const void *argv, dou
 int xtract_sharpness(const double *data, const int N, const void *argv, double *result)
 {
 
-    int n = N, rv;
+    int n = N, rv, z;
     double sl, g; /* sl = specific loudness */
-    double temp;
+    double temp, total_loudness;
 
     sl = g = 0.0;
     temp = 0.0;
+    total_loudness = 0.0;
 
     if(n > XTRACT_BARK_BANDS)
     {
@@ -863,13 +864,24 @@ int xtract_sharpness(const double *data, const int N, const void *argv, double *
 
     while(n--)
     {
-        sl = pow(data[n], 0.23);
-        g = (n < 15 ? 1.0 : 0.066 * exp(0.171 * n));
-        temp += n * g * sl;
+        /* Bark bands are numbered from z = 1 (von Bismarck 1974,
+         * Peeters 2004) */
+        z = n + 1;
+        sl = data[n] > 0.0 ? pow(data[n], 0.23) : 0.0;
+        g = (z < 15 ? 1.0 : 0.066 * exp(0.171 * z));
+        temp += z * g * sl;
+        total_loudness += sl;
     }
 
-    temp = 0.11 * temp / (double)N;
-    *result = (double)temp;
+    if(total_loudness == 0.0)
+    {
+        *result = 0.0;
+        return XTRACT_NO_RESULT;
+    }
+
+    /* Sharpness is the g-weighted centroid of specific loudness,
+     * normalised by the total loudness, in acums */
+    *result = 0.11 * temp / total_loudness;
 
     return rv;
 

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -819,6 +819,12 @@ int xtract_odd_even_ratio(const double *data, const int N, const void *argv, dou
         if((temp = data[n]))
         {
             h = (int)floor(freqs[n] / fund + 0.5);
+
+            /* Harmonics are numbered from 1: a bin nearest to harmonic
+             * zero is below the first harmonic and belongs to neither sum */
+            if(h == 0)
+                continue;
+
             if(XTRACT_IS_ODD(h))
             {
                 odd += temp;

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -628,11 +628,52 @@ TEST_CASE("xtract_sharpness", "[scalar][spectral]")
         REQUIRE(std::isfinite(result));
     }
 
+    SECTION("energy in a single low band gives 0.11 * z")
+    {
+        /* One non-zero band at index 4, i.e. Bark band z = 5 (bands are
+         * numbered from 1). Specific loudness 1.0^0.23 = 1, total
+         * loudness 1, g(z) = 1 below band 15, so per von Bismarck /
+         * Peeters: sharpness = 0.11 * z * g(z) * N'(z) / N'_total
+         *        = 0.11 * 5 = 0.55 */
+        double data[XTRACT_BARK_BANDS] = {0};
+        data[4] = 1.0;
+
+        REQUIRE(xtract_sharpness(data, XTRACT_BARK_BANDS, NULL, &result) == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(0.55).epsilon(1e-10));
+    }
+
+    SECTION("sharpness is invariant to overall loudness scaling")
+    {
+        /* Sharpness is normalised by total loudness, so scaling every
+         * band by the same factor must not change it. */
+        double data[XTRACT_BARK_BANDS];
+        double scaled[XTRACT_BARK_BANDS];
+        double result_scaled = 0.0;
+
+        for (int i = 0; i < XTRACT_BARK_BANDS; i++)
+        {
+            data[i] = 0.1 + 0.05 * i;
+            scaled[i] = 16.0 * data[i];
+        }
+
+        xtract_sharpness(data, XTRACT_BARK_BANDS, NULL, &result);
+        xtract_sharpness(scaled, XTRACT_BARK_BANDS, NULL, &result_scaled);
+        REQUIRE(result == Approx(result_scaled).epsilon(1e-10));
+    }
+
+    SECTION("silent input yields no result")
+    {
+        double data[XTRACT_BARK_BANDS] = {0};
+        result = 999.0;
+
+        REQUIRE(xtract_sharpness(data, XTRACT_BARK_BANDS, NULL, &result) == XTRACT_NO_RESULT);
+        REQUIRE(result == 0.0);
+    }
+
     SECTION("bands beyond XTRACT_BARK_BANDS are ignored")
     {
         /* The extra bands carry huge values that must not contribute:
-         * both calls then sum the same 26 bands, so the results differ
-         * only by the 1/N divisor. */
+         * both calls then sum the same 26 bands. */
         double data[30];
         double result26 = 0.0;
         double result30 = 0.0;
@@ -642,7 +683,7 @@ TEST_CASE("xtract_sharpness", "[scalar][spectral]")
 
         REQUIRE(xtract_sharpness(data, 30, NULL, &result30) == XTRACT_BAD_VECTOR_SIZE);
         REQUIRE(xtract_sharpness(data, XTRACT_BARK_BANDS, NULL, &result26) == XTRACT_SUCCESS);
-        REQUIRE(result30 * 30.0 == Approx(result26 * XTRACT_BARK_BANDS).epsilon(1e-10));
+        REQUIRE(result30 == Approx(result26).epsilon(1e-10));
     }
 }
 

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -611,6 +611,35 @@ TEST_CASE("xtract_spectral_standard_deviation", "[scalar][spectral]")
     }
 }
 
+TEST_CASE("xtract_odd_even_ratio", "[scalar][spectral]")
+{
+    double result = 0.0;
+    double fund = 100.0;
+
+    SECTION("computes the ratio of odd to even harmonic magnitudes")
+    {
+        /* Harmonics 1 and 3 (odd): 3.0 + 2.0 = 5.0
+         * Harmonics 2 and 4 (even): 0.5 + 0.4 = 0.9 */
+        double data[8] = {3.0, 0.5, 2.0, 0.4,
+                          100.0, 200.0, 300.0, 400.0};
+
+        REQUIRE(xtract_odd_even_ratio(data, 8, &fund, &result) == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(5.0 / 0.9).epsilon(1e-10));
+    }
+
+    SECTION("bins below the first harmonic are excluded")
+    {
+        /* The 20 Hz bin rounds to harmonic 0, which does not exist:
+         * harmonics are numbered from 1, so it must contribute to
+         * neither sum. Odd = 2.0 (h=1), even = 1.0 (h=2). */
+        double data[8] = {5.0, 2.0, 1.0, 0.0,
+                          20.0, 100.0, 200.0, 300.0};
+
+        REQUIRE(xtract_odd_even_ratio(data, 8, &fund, &result) == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(2.0).epsilon(1e-10));
+    }
+}
+
 TEST_CASE("xtract_sharpness", "[scalar][spectral]")
 {
     double result = 0.0;


### PR DESCRIPTION
## Summary

Two formula corrections traced back to their canonical sources, TDD throughout (each commit contains tests confirmed failing against the previous implementation).

### xtract_sharpness — normalise by total loudness
The denominator was the input array length rather than total loudness, so sharpness scaled with signal level instead of being the loudness-invariant acum measure defined by von Bismarck (1974) and formulated in Peeters (2004) — whose symbol N denotes total loudness Σ N'(z), not a count. Additionally:
- Bark bands are now numbered from 1 as the model specifies, fixing an off-by-one in both the z-weighting (band 1 previously contributed nothing) and the g(z) knee position.
- Non-positive band energies no longer produce NaN via pow().
- Silent input returns `XTRACT_NO_RESULT` instead of dividing by zero.
- The header doc previously described the input as spectrum magnitudes; it is Bark band coefficients. Corrected, with the model citation added (also to the descriptor author field).

### xtract_odd_even_ratio — exclude sub-fundamental bins
Harmonics are numbered from 1, so a bin whose frequency rounds to harmonic zero (below half the fundamental — reachable via permissive `xtract_harmonic_spectrum` thresholds) belongs to neither sum; it was counted as an *even* harmonic, skewing the ratio downward. The header doc now also makes the unit-agnosticism explicit: magnitude input gives an amplitude ratio, power-spectrum input gives the odd-to-even harmonic energy ratio of Peeters (2004) — no separate energy mode needed.

Descriptor metadata corrected along the way: tristimulus 1–3 and odd_even_ratio consume N/2 amplitudes followed by N/2 frequencies (`XTRACT_SPECTRAL_HARMONICS`, any amplitude unit), but were declared as amplitude-only input.

**Behaviour change note:** sharpness values change substantially (they become loudness-invariant and acum-calibrated); odd/even ratio changes only for inputs containing sub-fundamental content.

## Test plan

- New sharpness tests: exact single-band value (0.11·z), loudness-scaling invariance, silent-input handling; the band-clamp test updated for the new denominator (results now equal exactly rather than differing by the band-count ratio).
- New odd/even tests: hand-computed magnitude ratio, sub-fundamental exclusion.
- Full suite passes on both FFT backends: 514 assertions in 73 test cases (vDSP locally and an OOURA build of the suite).