### PR TITLE
chore: establish and enforce C99 as the project standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ make doc
 
 The generated HTML documentation can then be viewed by opening `doc/html/index.html`.
 
+## Code standard
+
+LibXtract is written in **C99**. Declarations are placed at the top of the
+block (C89 style) as a project convention; both the standard and the
+convention are enforced by the build flags (`-std=c99 -pedantic
+-Wdeclaration-after-statement -Wstrict-prototypes`). Thread-local storage
+uses a portability macro that resolves to C11 `_Thread_local`,
+`__declspec(thread)` (MSVC) or `__thread` (GCC/Clang). Bundled third-party
+code (`ooura`, `c-ringbuf`, `dywapitchtrack`) keeps its upstream style.
+
 ## License
 
 Copyright (C) 2012 Jamie Bullock

--- a/src/Make.config
+++ b/src/Make.config
@@ -1,9 +1,16 @@
 NAME := xtract
 DIRS := . c-ringbuf ooura dywapitchtrack
-FLAGS += --std=c99 -Wall -pedantic -I../include
+FLAGS += --std=c99 -Wall -pedantic -Wdeclaration-after-statement -Wstrict-prototypes -I../include
 
 ifeq ($(PLATFORM), Darwin)
     LDFLAGS = -framework Accelerate
 else
     FLAGS += -DUSE_OOURA
 endif
+
+# Style enforcement applies to first-party sources only; third-party code
+# (ooura, c-ringbuf, dywapitchtrack) keeps its upstream style
+STYLE_FLAGS := -Wdeclaration-after-statement -Wstrict-prototypes
+.build/c-ringbuf/%.o: FLAGS := $(filter-out $(STYLE_FLAGS),$(FLAGS))
+.build/dywapitchtrack/%.o: FLAGS := $(filter-out $(STYLE_FLAGS),$(FLAGS))
+.build/ooura/%.o: FLAGS := $(filter-out $(STYLE_FLAGS),$(FLAGS))

--- a/src/fini.c
+++ b/src/fini.c
@@ -26,9 +26,9 @@
 #include "xtract/libxtract.h"
 
 #ifdef __GNUC__
-__attribute__((destructor)) void fini()
+__attribute__((destructor)) void fini(void)
 #else
-void _fini()
+void _fini(void)
 #endif
 {
     xtract_free_fft();

--- a/src/helper.c
+++ b/src/helper.c
@@ -113,8 +113,10 @@ int xtract_smoothed(const double *data, const int N, const void *argv, double *r
 int xtract_is_denormal(double const d)
 {
     uint64_t bits;
+    int exponent;
+
     memcpy(&bits, &d, sizeof(bits));
-    int exponent = (int)((bits >> 52) & 0x7ff);
+    exponent = (int)((bits >> 52) & 0x7ff);
     return exponent == 0 && d != 0.0;
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -526,9 +526,9 @@ void xtract_free_window(double *window)
 }
 
 #ifdef __GNUC__
-__attribute__((constructor)) void init()
+__attribute__((constructor)) void init(void)
 #else
-void _init()
+void _init(void)
 #endif
 {
 #ifdef USE_OOURA

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -298,6 +298,7 @@ int xtract_spectral_skewness(const double *data, const int N, const void *argv, 
     const double *freqs, *amps;
     const double arg0 = ((double *)argv)[0];
     const double arg1 = ((double *)argv)[1];
+    double sum_amps = 0.0;
 
     *result = 0.0;
 
@@ -310,8 +311,6 @@ int xtract_spectral_skewness(const double *data, const int N, const void *argv, 
 
     amps = data;
     freqs = data + m;
-
-    double sum_amps = 0.0;
 
     while(m--)
     {
@@ -337,6 +336,7 @@ int xtract_spectral_kurtosis(const double *data, const int N, const void *argv, 
     const double *freqs, *amps;
     const double arg0 = ((double *)argv)[0];
     const double arg1 = ((double *)argv)[1];
+    double sum_amps = 0.0;
 
     if (((double *)argv)[1] == 0.0)
     {
@@ -350,7 +350,6 @@ int xtract_spectral_kurtosis(const double *data, const int N, const void *argv, 
     freqs = data + m;
 
     *result = 0.0;
-    double sum_amps = 0.0;
 
     while(m--)
     {
@@ -444,8 +443,9 @@ int xtract_tristimulus_2(const double *data, const int N, const void *argv, doub
 {
     int n = N >> 1, i;
     double den, p2, p3, p4, ps, fund, temp, h;
-    den = p2 = p3 = p4 = ps = fund = temp = h = 0.0;
     const double *freqs;
+
+    den = p2 = p3 = p4 = ps = fund = temp = h = 0.0;
 
     fund = *(double *)argv;
     freqs = data + n;
@@ -899,6 +899,7 @@ int xtract_spectral_slope(const double *data, const int N, const void *argv, dou
     const double *freqs, *amps;
     double f, a,
           F, A, FA, FXTRACT_SQ; /* sums of freqs, amps, freq * amps, freq squared */
+    double temp;
     int n, M;
 
     F = A = FA = FXTRACT_SQ = 0.0;
@@ -917,7 +918,7 @@ int xtract_spectral_slope(const double *data, const int N, const void *argv, dou
         FXTRACT_SQ += f * f;
     }
 
-    double temp = (double)M * FXTRACT_SQ - F * F;
+    temp = (double)M * FXTRACT_SQ - F * F;
 
     if (A == 0 || temp == 0)
     {

--- a/src/stateful.c
+++ b/src/stateful.c
@@ -67,7 +67,9 @@ void xtract_last_n_state_delete(xtract_last_n_state *last_n_state)
 int xtract_last_n(const xtract_last_n_state *state, const double *data, const int N, const void *argv, double *result)
 {
     size_t N_bytes = N * sizeof(double);
-    
+    size_t used;
+    size_t result_offset;
+
     if (N_bytes != ringbuf_capacity(state->ringbuf))
     {
         fprintf(stderr, "libxtract: error: xtract_last_n(): inconsitent size");
@@ -75,8 +77,8 @@ int xtract_last_n(const xtract_last_n_state *state, const double *data, const in
     }
     
     ringbuf_memcpy_into(state->ringbuf, data, sizeof(double));
-    size_t used = ringbuf_bytes_used(state->ringbuf);
-    size_t result_offset = N - (used / sizeof(double));
+    used = ringbuf_bytes_used(state->ringbuf);
+    result_offset = N - (used / sizeof(double));
     
     /* Copy at end of result so last value is most recent */
     ringbuf_memcpy_from(result + result_offset, state->ringbuf, used, false);

--- a/src/vector.c
+++ b/src/vector.c
@@ -582,6 +582,7 @@ int xtract_mmbses(const double *data, const int N, const void *argv, double *res
         double imagMean = 0, imagVariance = 0;
         double covariance = 0;
         double energy = 0;
+        double temp;
 
         result[filter] = 0.0;
         for(n = 0; n < N; n++)
@@ -630,7 +631,7 @@ int xtract_mmbses(const double *data, const int N, const void *argv, double *res
         if(count > 1)
             covariance /= (count - 1);
         // Calculate the final Mel based Multi-Band Spectral Entropy Signature coefficients
-        double temp = realVariance*imagVariance-XTRACT_SQ(covariance);
+        temp = realVariance*imagVariance-XTRACT_SQ(covariance);
 
         if (temp < XTRACT_LOG_LIMIT)
             temp = XTRACT_LOG_LIMIT_DB;


### PR DESCRIPTION
## Summary

The README requires a C99 compiler and the build already compiles with `--std=c99`, but the standard was never stated or enforced, and the declarations-at-top convention existed only as an unwritten rule. An investigation established: the code is de facto C99 (// comments, stdbool/stdint, for-loop declarations), strict C89 is unreachable anyway (Apple's Accelerate headers require C99+ features), and the only strict-C99 deviations were two missing prototypes. Three commits:

1. **`(void)` prototypes for the library constructor/destructor** — `init()` and `fini()` were the only `-pedantic-errors` failures under C99 and the source of the only persistent build warnings. The library is now strictly C99-clean.

2. **Enforce declaration placement mechanically** — the seven mid-block declarations in first-party code are moved to the top of their blocks, and `-Wdeclaration-after-statement -Wstrict-prototypes` are added to the library build so both the standard floor and the style convention are compiler-checked from now on. Third-party directories (`ooura`, `c-ringbuf`, `dywapitchtrack`) are exempted via pattern-specific make variables, keeping their upstream style and the build warning-free.

3. **Document the standard in the README** — a "Code standard" section stating C99, the C89-style declaration convention, the enforcing flags, and the thread-local portability macro (C11 `_Thread_local` / `__declspec(thread)` / `__thread`).

No behavioural changes — declaration moves are pure reorderings within blocks.

## Test plan

- Full suite passes: 514 assertions in 73 test cases.
- Library builds warning-free on the vDSP backend; all ten first-party sources also compile warning-free with the new flags under `-DUSE_OOURA`.
- `-std=c99 -pedantic-errors` syntax check passes for every first-party source file.