### PR TITLE
refactor: remove dead initial stores and add static analysis enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
           make
           make check
 
+      - name: Static analysis (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: make analyze
+
       - name: Install Node.js headers (Linux/macOS)
         if: runner.os != 'Windows'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HPATH = include/xtract
 
 export XTRACT_VERSION PREFIX LIBRARY
 
-.PHONY: examples clean install doc src swig bench
+.PHONY: examples clean install doc src swig bench analyze
 
 all: src examples
 
@@ -25,6 +25,9 @@ swig: src
 
 check: src
 	@$(MAKE) -C tests check
+
+analyze:
+	@$(MAKE) -C src analyze
 
 bench: src
 	@$(MAKE) -C bench bench

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ uses a portability macro that resolves to C11 `_Thread_local`,
 `__declspec(thread)` (MSVC) or `__thread` (GCC/Clang). Bundled third-party
 code (`ooura`, `c-ringbuf`, `dywapitchtrack`) keeps its upstream style.
 
+Initialisation convention: initialise a variable at its declaration when
+the initial value is known and meaningful (accumulators to zero, copies of
+parameters); otherwise declare it uninitialised and assign on every path
+before use. Never defensively zero a variable that is unconditionally
+assigned later — dead stores hide missing-assignment bugs from the
+compiler. This is checked by `-Wconditional-uninitialized` (clang builds)
+and by `make analyze`, which runs the clang static analyzer over the
+first-party sources and fails on any finding; CI runs it on Linux and
+macOS.
+
 ## License
 
 Copyright (C) 2012 Jamie Bullock

--- a/src/Make.config
+++ b/src/Make.config
@@ -4,6 +4,8 @@ FLAGS += --std=c99 -Wall -pedantic -Wdeclaration-after-statement -Wstrict-protot
 
 ifeq ($(PLATFORM), Darwin)
     LDFLAGS = -framework Accelerate
+    # clang-only: warn when a variable may be read uninitialised on some paths
+    FLAGS += -Wconditional-uninitialized
 else
     FLAGS += -DUSE_OOURA
 endif
@@ -14,3 +16,19 @@ STYLE_FLAGS := -Wdeclaration-after-statement -Wstrict-prototypes
 .build/c-ringbuf/%.o: FLAGS := $(filter-out $(STYLE_FLAGS),$(FLAGS))
 .build/dywapitchtrack/%.o: FLAGS := $(filter-out $(STYLE_FLAGS),$(FLAGS))
 .build/ooura/%.o: FLAGS := $(filter-out $(STYLE_FLAGS),$(FLAGS))
+
+# Static analysis of first-party sources (dead stores, uninitialised reads,
+# null dereferences). Requires clang; fails on any finding.
+ANALYZE_SRC := $(wildcard *.c)
+analyze:
+	@output=$$(for f in $(ANALYZE_SRC); do \
+		clang --analyze -Xanalyzer -analyzer-output=text $(filter-out -Wconditional-uninitialized,$(FLAGS)) $$f -o /dev/null 2>&1; \
+	done); \
+	if [ -n "$$output" ]; then printf '%s\n' "$$output"; exit 1; fi
+	@echo "static analysis clean"
+
+.PHONY: analyze
+
+# Make.config is included before the library rule in the Makefile, so reset
+# the default goal or analyze would become the default target
+.DEFAULT_GOAL :=

--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -30,7 +30,7 @@
 xtract_function_descriptor_t *xtract_make_descriptors(void)
 {
 
-    int f , F;
+    int f;
     char *name, *p_name, *desc, *p_desc, *author;
     double *argv_min, *argv_max, *argv_def, *result_min, *result_max;
     int *argc, *year, *argv_donor;
@@ -40,7 +40,7 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
     xtract_function_descriptor_t *fd, *d;
     xtract_type_t *argv_type;
 
-    f = F = XTRACT_FEATURES;
+    f = XTRACT_FEATURES;
 
     fd = (xtract_function_descriptor_t*)malloc(XTRACT_FEATURES * sizeof(xtract_function_descriptor_t));
     if(fd == NULL)

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -445,7 +445,7 @@ int xtract_tristimulus_2(const double *data, const int N, const void *argv, doub
     double den, p2, p3, p4, ps, fund, temp, h;
     const double *freqs;
 
-    den = p2 = p3 = p4 = ps = fund = temp = h = 0.0;
+    den = p2 = p3 = p4 = 0.0;
 
     fund = *(double *)argv;
     freqs = data + n;
@@ -695,8 +695,6 @@ int xtract_crest(const double *data, const int N, const void *argv, double *resu
 
     double max, mean;
 
-    max = mean = 0.0;
-
     max = *(double *)argv;
     mean = *((double *)argv+1);
 
@@ -716,8 +714,6 @@ int xtract_noisiness(const double *data, const int N, const void *argv, double *
 {
 
     double h, i, p; /*harmonics, inharmonics, partials */
-
-    i = p = h = 0.0;
 
     h = *(double *)argv;
     p = *((double *)argv+1);
@@ -855,7 +851,6 @@ int xtract_sharpness(const double *data, const int N, const void *argv, double *
     double sl, g; /* sl = specific loudness */
     double temp, total_loudness;
 
-    sl = g = 0.0;
     temp = 0.0;
     total_loudness = 0.0;
 
@@ -1022,7 +1017,7 @@ int xtract_hps(const double *data, const int N, const void *argv, double *result
 
     peak_index = 0;
 
-    tempProduct = peak = 0;
+    peak = 0;
     for (i = 0; i < M; ++i)
     {
         tempProduct = data [i] * data [i * 2] * data [i * 3];

--- a/src/vector.c
+++ b/src/vector.c
@@ -825,7 +825,7 @@ int xtract_peak_spectrum(const double *data, const int N, const void *argv, doub
     double threshold, max, y, y2, y3, p, q;
     int n = N, rv = XTRACT_SUCCESS;
 
-    threshold = max = y = y2 = y3 = p = q = 0.0;
+    threshold = max = q = 0.0;
 
     if(argv != NULL)
     {
@@ -900,8 +900,6 @@ int xtract_harmonic_spectrum(const double *data, const int N, const void *argv, 
         memset(result, 0, N * sizeof(double));
         return XTRACT_NO_RESULT;
     }
-
-    ratio = nearest = distance = 0.0;
 
     while(n--)
     {


### PR DESCRIPTION
## Summary

Follow-up to the C-standard work: the codebase mixed three initialisation patterns, the worst being defensive zero-assignments to variables that are unconditionally reassigned before any read. These dead stores add noise and actively defeat `-Wuninitialized` — a zeroed variable can never be flagged when the logic forgets to compute its real value. Three commits:

1. **Remove dead initial stores** — all sites identified by the clang static analyzer (`deadcode.DeadStores`) on both FFT backends: the chained zeroings in `tristimulus_2`, `crest`, `noisiness`, `sharpness`, `hps`, `peak_spectrum`, and `harmonic_spectrum` (keeping the genuinely needed zero-initialisations of accumulators and of `q`, which is read when argv is NULL), plus the entirely unused variable `F` in `xtract_make_descriptors`. No behavioural change; analyzer reports zero findings after.

2. **Automatic enforcement** —
   - `make analyze` (root and `src/`) runs the clang static analyzer over the first-party sources with the production flags and **fails on any finding**; third-party directories are not analysed.
   - CI runs `make analyze` on Linux and macOS (clang is preinstalled on both runners; the Windows MinGW job has no clang).
   - `-Wconditional-uninitialized` is enabled for regular macOS builds (clang-only flag — gcc rejects unknown `-W` options, and the Linux gap is covered by the analyzer step). Verified zero warnings on all first-party and bundled sources.

3. **Document the convention** in the README code-standard section: initialise at declaration when the value is known and meaningful; otherwise declare uninitialised and assign on every path; never defensively zero.

The full cosmetic migration of remaining declare-then-assign locals to initialise-at-declaration is deliberately **not** included — it's a wide, error-prone sweep that should wait until per-function test coverage exists to catch transcription regressions.

## Test plan

- Full suite passes: 515 assertions in 73 test cases.
- `make analyze` clean; `-Wconditional-uninitialized` clean on every source file.
- Library builds warning-free on the vDSP backend; analyzer findings verified identical (and now empty) under `-DUSE_OOURA`.