### PR TITLE
chore: update CI actions to current major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
 
       - name: Setup Node.js (Linux/macOS)
         if: runner.os != 'Windows'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,7 +21,7 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

CI annotations have started flagging the Node.js 20 deprecation: `actions/checkout@v4` and `actions/setup-java@v4` will be forced onto Node 24 from June 16 2026 and removed from runners in September. This bumps all GitHub-maintained actions to their current major versions (all Node 24 native): checkout v4 → v6, setup-java v4 → v5, setup-node v4 → v6, in both workflows. `msys2/setup-msys2@v2` is already the current major.

The `windows-latest` → `windows-2025-vs2026` image redirect noted in recent runs needs no change — the alias follows the new image automatically.

## Test plan

CI on this PR exercises the updated actions directly across all three platforms.