### PR TITLE
chore: run the test suite under AddressSanitizer and UBSan in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
         if: runner.os != 'Windows'
         run: make analyze
 
+      - name: Sanitizer tests (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: make check-asan
+
       - name: Install Node.js headers (Linux/macOS)
         if: runner.os != 'Windows'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HPATH = include/xtract
 
 export XTRACT_VERSION PREFIX LIBRARY
 
-.PHONY: examples clean install doc src swig bench analyze
+.PHONY: examples clean install doc src swig bench analyze check-asan
 
 all: src examples
 
@@ -28,6 +28,20 @@ check: src
 
 analyze:
 	@$(MAKE) -C src analyze
+
+# Rebuild the library and tests with AddressSanitizer and UBSan and run the
+# suite; catches memory errors and undefined behaviour that static analysis
+# cannot see (e.g. out-of-bounds access through opaque library calls).
+# Cleans before and after so sanitised objects never mix with normal builds.
+SANITIZE_FLAGS = -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g
+check-asan:
+	@$(MAKE) -C src clean
+	@$(MAKE) -C tests clean
+	@$(MAKE) -C src EXTRA_FLAGS="$(SANITIZE_FLAGS)"
+	@$(MAKE) -C tests check EXTRA_FLAGS="$(SANITIZE_FLAGS)"
+	@$(MAKE) -C src clean
+	@$(MAKE) -C tests clean
+	@$(MAKE) -C src
 
 bench: src
 	@$(MAKE) -C bench bench

--- a/src/Make.config
+++ b/src/Make.config
@@ -1,6 +1,7 @@
 NAME := xtract
 DIRS := . c-ringbuf ooura dywapitchtrack
 FLAGS += --std=c99 -Wall -pedantic -Wdeclaration-after-statement -Wstrict-prototypes -I../include
+FLAGS += $(EXTRA_FLAGS)
 
 ifeq ($(PLATFORM), Darwin)
     LDFLAGS = -framework Accelerate
@@ -9,6 +10,10 @@ ifeq ($(PLATFORM), Darwin)
 else
     FLAGS += -DUSE_OOURA
 endif
+
+# Unused for the static archive, but a shared library must link the
+# sanitizer runtimes when EXTRA_FLAGS carries -fsanitize
+LDFLAGS += $(EXTRA_FLAGS)
 
 # Style enforcement applies to first-party sources only; third-party code
 # (ooura, c-ringbuf, dywapitchtrack) keeps its upstream style

--- a/tests/Make.config
+++ b/tests/Make.config
@@ -3,6 +3,7 @@ SUFFIX := .cpp
 DIRS := .
 LIBRARY :=
 FLAGS := -I../include -std=c++0x
+FLAGS += $(EXTRA_FLAGS)
 
 ifeq ($(OS),Windows_NT)
     LDDEPS := ../src/libxtract.lib
@@ -17,3 +18,5 @@ ifneq ($(OS),Windows_NT)
         LDFLAGS += -framework Accelerate
     endif
 endif
+
+LDFLAGS += $(EXTRA_FLAGS)


### PR DESCRIPTION
## Summary

Static analysis and sanitizers catch disjoint bug classes: the clang analyzer reasons about paths it can see, while ASan/UBSan observe actual execution — including through opaque calls. The `xtract_autocorrelation_fft` buffer over-read/over-write fixed in the recent audit is the motivating example: invisible to `make analyze` (the analyzer can't model vDSP's access pattern) but caught immediately by an ASan run of the suite. As test coverage grows, every new test becomes a sanitizer probe for free.

- New `make check-asan` target: rebuilds the library and tests with `-fsanitize=address,undefined -fno-sanitize-recover=all` and runs the full suite. Cleans before and after so sanitised objects never contaminate normal builds.
- Plumbing: `EXTRA_FLAGS` is now appended to compile flags in `src/` and `tests/` (and to link flags for the test binary, where the sanitizer runtime must be linked).
- CI runs the sanitizer suite on Linux and macOS after the regular checks (the MinGW job is excluded — no practical ASan there).

## Test plan

- `make check-asan` passes locally: all 515 assertions, zero sanitizer reports.
- A regular `make && make check` immediately afterwards is unaffected (clean isolation verified).
- CI on this PR exercises the new step on both platforms.