### PR TITLE
chore: add cppcheck and stricter warnings, fix unchecked calloc it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
         if: runner.os != 'Windows'
         run: make check-asan
 
+      - name: cppcheck (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y cppcheck
+          make cppcheck
+
       - name: Install Node.js headers (Linux/macOS)
         if: runner.os != 'Windows'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HPATH = include/xtract
 
 export XTRACT_VERSION PREFIX LIBRARY
 
-.PHONY: examples clean install doc src swig bench analyze check-asan
+.PHONY: examples clean install doc src swig bench analyze check-asan cppcheck
 
 all: src examples
 
@@ -28,6 +28,14 @@ check: src
 
 analyze:
 	@$(MAKE) -C src analyze
+
+# Requires cppcheck; checks all preprocessor configurations of the
+# first-party sources (vDSP and OOURA branches alike)
+cppcheck:
+	@cppcheck --enable=warning,performance,portability --std=c99 \
+		--inline-suppr --error-exitcode=1 --quiet \
+		-I include -I src src/*.c
+	@echo "cppcheck clean"
 
 # Rebuild the library and tests with AddressSanitizer and UBSan and run the
 # suite; catches memory errors and undefined behaviour that static analysis

--- a/src/Make.config
+++ b/src/Make.config
@@ -1,6 +1,6 @@
 NAME := xtract
 DIRS := . c-ringbuf ooura dywapitchtrack
-FLAGS += --std=c99 -Wall -pedantic -Wdeclaration-after-statement -Wstrict-prototypes -I../include
+FLAGS += --std=c99 -Wall -Wextra -Wno-unused-parameter -Wshadow -pedantic -Wdeclaration-after-statement -Wstrict-prototypes -I../include
 FLAGS += $(EXTRA_FLAGS)
 
 ifeq ($(PLATFORM), Darwin)
@@ -15,9 +15,9 @@ endif
 # sanitizer runtimes when EXTRA_FLAGS carries -fsanitize
 LDFLAGS += $(EXTRA_FLAGS)
 
-# Style enforcement applies to first-party sources only; third-party code
+# Stricter warnings apply to first-party sources only; third-party code
 # (ooura, c-ringbuf, dywapitchtrack) keeps its upstream style
-STYLE_FLAGS := -Wdeclaration-after-statement -Wstrict-prototypes
+STYLE_FLAGS := -Wdeclaration-after-statement -Wstrict-prototypes -Wextra -Wno-unused-parameter -Wshadow
 .build/c-ringbuf/%.o: FLAGS := $(filter-out $(STYLE_FLAGS),$(FLAGS))
 .build/dywapitchtrack/%.o: FLAGS := $(filter-out $(STYLE_FLAGS),$(FLAGS))
 .build/ooura/%.o: FLAGS := $(filter-out $(STYLE_FLAGS),$(FLAGS))

--- a/src/vector.c
+++ b/src/vector.c
@@ -401,6 +401,8 @@ int xtract_autocorrelation_fft(const double *data, const int N, const void *argv
 #ifdef USE_OOURA
     /* Zero pad the input vector */
     rfft = (double *)calloc(M, sizeof(double));
+    if(rfft == NULL)
+        return XTRACT_MALLOC_FAILED;
     memcpy(rfft, data, N * sizeof(double));
 
     rdft(M, 1, rfft, ooura_data_autocorrelation_fft.ooura_ip,

--- a/src/vector.c
+++ b/src/vector.c
@@ -488,6 +488,7 @@ static int filterbank_spectrogram(const double *data, const int N, const xtract_
         if(result[filter] < XTRACT_LOG_LIMIT)
             result[filter] = XTRACT_LOG_LIMIT_DB;
         else
+            /* cppcheck-suppress invalidFunctionArg */
             result[filter] = log(result[filter]);
     }
 


### PR DESCRIPTION
## Summary

Follow-up to the static-analysis discussion, adding the cheap checks that trialled clean (or found something):

1. **fix: unchecked `calloc` in `xtract_autocorrelation_fft`** — the OOURA zero-padding buffer allocation went straight into `memcpy` with no NULL check, the one gap left by the earlier allocation-check sweep. Found by cppcheck during the trial; the clang analyzer does not flag missing OOM checks by default, so the existing gate could not catch this class.
2. **`-Wextra -Wshadow` for first-party sources** — both clean on the current tree (`-Wshadow` found nothing; `-Wextra`'s only output was `-Wunused-parameter` from the uniform feature signature, where `argv`/`data` are deliberately unused, hence `-Wno-unused-parameter`). Third-party directories are exempted via the existing first-party-only flag filter (ringbuf would emit 6 warnings otherwise).
3. **`make cppcheck`, gated in CI on Linux** — checks all preprocessor configurations (vDSP and OOURA branches in one run), fails on any finding via `--error-exitcode=1`. One inline suppression for a false positive where cppcheck does not model the `XTRACT_LOG_LIMIT` guard before a `log()` call.

## Test plan

- Full suite passes on both FFT backends (515 assertions; OOURA verified via a `-DUSE_OOURA` build since the calloc fix is in that path).
- Library builds warning-free under the new flags on both backend configurations.
- `make cppcheck` clean locally (cppcheck 2.21); CI exercises the apt-packaged version.