### PR TITLE
chore: add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 4 * * 1'
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: c-cpp
+
+      - name: Build
+        run: make
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

Adds GitHub's CodeQL static analysis (free for public repositories): interprocedural dataflow analysis complementing the clang analyzer and cppcheck already gating CI. Runs on pushes to main, PRs, and a weekly schedule (catching newly added queries against unchanged code). The build step is a plain `make` on Linux, so the OOURA backend is what gets analysed.

## Test plan

The workflow runs on this PR itself; findings (if any) appear as check annotations and in the Security tab.