### PR TITLE
chore: add make coverage target (gcov/lcov)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ doc/html
 .build
 dist
 
+# Coverage (make coverage)
+*.gcno
+*.gcda
+coverage.info
+coverage-html
+
 # Project-specific files
 examples/simpletest/simpletest
 tests/xttest

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HPATH = include/xtract
 
 export XTRACT_VERSION PREFIX LIBRARY
 
-.PHONY: examples clean install doc src swig bench analyze check-asan cppcheck
+.PHONY: examples clean install doc src swig bench analyze check-asan cppcheck coverage
 
 all: src examples
 
@@ -47,6 +47,29 @@ check-asan:
 	@$(MAKE) -C tests clean
 	@$(MAKE) -C src EXTRA_FLAGS="$(SANITIZE_FLAGS)"
 	@$(MAKE) -C tests check EXTRA_FLAGS="$(SANITIZE_FLAGS)"
+	@$(MAKE) -C src clean
+	@$(MAKE) -C tests clean
+	@$(MAKE) -C src
+
+# Rebuild the library and tests with gcov instrumentation, run the suite, and
+# produce a line/branch coverage report for the first-party sources. Requires
+# lcov (provides lcov/genhtml; uses gcov from the active toolchain). Third-party
+# code (ooura, c-ringbuf, dywapitchtrack) keeps its upstream style and is out of
+# scope for the test baseline, so it is filtered out of the report. Cleans
+# before and after so instrumented objects never mix with normal builds.
+COVERAGE_FLAGS = --coverage
+COVERAGE_IGNORE = --ignore-errors unused,inconsistent,format,empty,gcov,unsupported
+coverage:
+	@$(MAKE) -C src clean
+	@$(MAKE) -C tests clean
+	@$(MAKE) -C src EXTRA_FLAGS="$(COVERAGE_FLAGS)"
+	@$(MAKE) -C tests check EXTRA_FLAGS="$(COVERAGE_FLAGS)"
+	@lcov --capture --directory src/.build --output-file coverage.info $(COVERAGE_IGNORE)
+	@lcov --remove coverage.info '*/ooura/*' '*/c-ringbuf/*' '*/dywapitchtrack/*' \
+		--output-file coverage.info $(COVERAGE_IGNORE)
+	@lcov --list coverage.info $(COVERAGE_IGNORE)
+	@genhtml coverage.info --output-directory coverage-html $(COVERAGE_IGNORE) >/dev/null
+	@echo "Coverage report written to coverage-html/index.html"
 	@$(MAKE) -C src clean
 	@$(MAKE) -C tests clean
 	@$(MAKE) -C src


### PR DESCRIPTION
First step of roadmap milestone 1.1, item 3 (Test Coverage Baseline): stand up the coverage measurement the roadmap calls for, so "untested" becomes a precise, reproducible worklist rather than a guess.

Adds a `make coverage` target that:
- rebuilds the library and test suite with `--coverage` instrumentation (mirroring the existing `check-asan` `EXTRA_FLAGS` pattern), runs the suite, and produces a line/function report via lcov;
- filters out the bundled third-party code (`ooura`, `c-ringbuf`, `dywapitchtrack`), which is out of scope for the LibXtract test baseline;
- prints an lcov summary and writes an HTML report to `coverage-html/`;
- cleans before and after so instrumented objects never mix with normal builds.

Coverage outputs (`*.gcno`, `*.gcda`, `coverage.info`, `coverage-html/`) are gitignored.

Requires `lcov` (provides `lcov`/`genhtml`; uses `gcov` from the active toolchain). Local developer target only — no CI job in this PR.

## Baseline it reports (first-party sources)

**63.9% lines (1078/1686), 70.4% functions (69/98)**

| File | Line coverage |
|---|---|
| window.c | 0.0% |
| helper.c | 31.9% |
| delta.c | 52.6% |
| init.c | 63.9% |
| vector.c | 67.5% |
| scalar.c | 73.5% |

This baseline drives the per-area test PRs that follow.

`make` and `make check` pass locally (515 assertions, 73 test cases).