### PR TITLE
feat: add spectral/scalar feature tests

### DIFF
--- a/tests/xttest_scalar.cpp
+++ b/tests/xttest_scalar.cpp
@@ -2109,3 +2109,156 @@ TEST_CASE("xtract_flatness numerical stability", "[scalar]")
         REQUIRE(rv == XTRACT_NO_RESULT);
     }
 }
+
+/* The tristimulus features partition harmonic energy into three bands by
+ * harmonic number h = round(freq / fundamental): band 1 is h == 1, band 2 is
+ * h in {2,3,4}, band 3 is h >= 5. Each is the band energy over the total
+ * energy. Input follows the xtract_spectrum() layout: amplitudes in
+ * data[0..N/2), frequencies in data[N/2..N). The shared spectrum below has six
+ * harmonics of a 100 Hz fundamental with amplitudes {4,3,2,1,5,2}, so the total
+ * is 17 and the three bands hold 4, (3+2+1)=6 and (5+2)=7 respectively. */
+
+TEST_CASE("xtract_tristimulus_1", "[scalar]")
+{
+    double fund = 100.0;
+    double result = -1.0;
+
+    SECTION("ratio of the fundamental's energy to the total")
+    {
+        double data[] = {4, 3, 2, 1, 5, 2, 100, 200, 300, 400, 500, 600};
+        int rv = xtract_tristimulus_1(data, 12, &fund, &result);
+        REQUIRE(rv == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(4.0 / 17.0).epsilon(EPSILON));
+    }
+
+    SECTION("no fundamental partial yields no result")
+    {
+        /* amplitude at 100 Hz (h == 1) is zero, so band 1 is empty */
+        double data[] = {0, 3, 2, 1, 5, 2, 100, 200, 300, 400, 500, 600};
+        int rv = xtract_tristimulus_1(data, 12, &fund, &result);
+        REQUIRE(rv == XTRACT_NO_RESULT);
+        REQUIRE(result == 0.0);
+    }
+}
+
+TEST_CASE("xtract_tristimulus_2", "[scalar]")
+{
+    double fund = 100.0;
+    double result = -1.0;
+
+    SECTION("ratio of the 2nd-4th harmonics' energy to the total")
+    {
+        double data[] = {4, 3, 2, 1, 5, 2, 100, 200, 300, 400, 500, 600};
+        int rv = xtract_tristimulus_2(data, 12, &fund, &result);
+        REQUIRE(rv == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(6.0 / 17.0).epsilon(EPSILON));
+    }
+
+    SECTION("no 2nd-4th harmonics yields no result")
+    {
+        double data[] = {4, 0, 0, 0, 5, 2, 100, 200, 300, 400, 500, 600};
+        int rv = xtract_tristimulus_2(data, 12, &fund, &result);
+        REQUIRE(rv == XTRACT_NO_RESULT);
+        REQUIRE(result == 0.0);
+    }
+}
+
+TEST_CASE("xtract_tristimulus_3", "[scalar]")
+{
+    double fund = 100.0;
+    double result = -1.0;
+
+    SECTION("ratio of the 5th-and-higher harmonics' energy to the total")
+    {
+        double data[] = {4, 3, 2, 1, 5, 2, 100, 200, 300, 400, 500, 600};
+        int rv = xtract_tristimulus_3(data, 12, &fund, &result);
+        REQUIRE(rv == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(7.0 / 17.0).epsilon(EPSILON));
+    }
+
+    SECTION("no high harmonics yields no result")
+    {
+        double data[] = {4, 3, 2, 1, 0, 0, 100, 200, 300, 400, 500, 600};
+        int rv = xtract_tristimulus_3(data, 12, &fund, &result);
+        REQUIRE(rv == XTRACT_NO_RESULT);
+        REQUIRE(result == 0.0);
+    }
+}
+
+TEST_CASE("xtract_spectral_inharmonicity", "[scalar]")
+{
+    double fund = 100.0;
+    double result = -1.0;
+
+    SECTION("a perfectly harmonic spectrum has zero inharmonicity")
+    {
+        /* Every partial sits exactly on a multiple of the fundamental, so
+         * |freq - h*fund| is zero for all bins. */
+        double data[] = {1.0, 1.0, 100.0, 200.0};
+        int rv = xtract_spectral_inharmonicity(data, 4, &fund, &result);
+        REQUIRE(rv == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(0.0).margin(EPSILON));
+    }
+
+    SECTION("a detuned partial gives the amplitude-weighted deviation")
+    {
+        /* result = 2 * sum(|f - h*fund| * a^2) / (fund * sum(a^2)).
+         * Bin 0 (100 Hz) is on pitch; bin 1 (205 Hz, h=2) is 5 Hz sharp.
+         * = 2 * (5 * 1) / (100 * 2) = 10 / 200 = 0.05 */
+        double data[] = {1.0, 1.0, 100.0, 205.0};
+        int rv = xtract_spectral_inharmonicity(data, 4, &fund, &result);
+        REQUIRE(rv == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(0.05).epsilon(EPSILON));
+    }
+
+    SECTION("a zero fundamental yields no result")
+    {
+        double data[] = {1.0, 1.0, 100.0, 205.0};
+        double zero = 0.0;
+        int rv = xtract_spectral_inharmonicity(data, 4, &zero, &result);
+        REQUIRE(rv == XTRACT_NO_RESULT);
+        REQUIRE(result == 0.0);
+    }
+
+    SECTION("an all-zero amplitude spectrum yields no result")
+    {
+        double data[] = {0.0, 0.0, 100.0, 205.0};
+        int rv = xtract_spectral_inharmonicity(data, 4, &fund, &result);
+        REQUIRE(rv == XTRACT_NO_RESULT);
+        REQUIRE(result == 0.0);
+    }
+}
+
+TEST_CASE("xtract_peak", "[scalar]")
+{
+    double result = -1.0;
+
+    SECTION("the last sample is the maximum and clears the threshold")
+    {
+        /* current = data[N-1] = 10, maximum = 10, average = 16/4 = 4,
+         * threshold = 0, so current >= average + threshold. */
+        double data[] = {1.0, 2.0, 3.0, 10.0};
+        double threshold = 0.0;
+        int rv = xtract_peak(data, 4, &threshold, &result);
+        REQUIRE(rv == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(10.0).epsilon(EPSILON));
+    }
+
+    SECTION("the last sample is not the maximum yields no result")
+    {
+        double data[] = {1.0, 10.0, 3.0, 2.0};
+        double threshold = 0.0;
+        int rv = xtract_peak(data, 4, &threshold, &result);
+        REQUIRE(rv == XTRACT_NO_RESULT);
+    }
+
+    SECTION("the last sample is the maximum but below threshold yields no result")
+    {
+        /* current = maximum = 4, average = 2.5, threshold = 5, so
+         * current < average + threshold (4 < 7.5). */
+        double data[] = {1.0, 2.0, 3.0, 4.0};
+        double threshold = 5.0;
+        int rv = xtract_peak(data, 4, &threshold, &result);
+        REQUIRE(rv == XTRACT_NO_RESULT);
+    }
+}

--- a/tests/xttest_vector.cpp
+++ b/tests/xttest_vector.cpp
@@ -1175,3 +1175,104 @@ TEST_CASE("xtract_init_fft DCT does not clobber MFCC", "[init]")
         REQUIRE(rv == XTRACT_SUCCESS);
     }
 }
+
+TEST_CASE("xtract_mmbses", "[vector]")
+{
+    /* Mel-based Multi-Band Spectral Entropy Signature. The input is N complex
+     * bins as interleaved real/imag pairs (2*N doubles); argv is an
+     * xtract_mel_filter. For each filter the energy is the mean magnitude of
+     * the filtered bins scaled by 2*pi. -96.0 is the library's log floor
+     * (XTRACT_LOG_LIMIT_DB), used when a log argument is below ~0. */
+    const double LOG_LIMIT_DB = -96.0;
+
+    SECTION("an all-zero filter produces a zero coefficient")
+    {
+        /* No bin passes the filter (count == 0), so the band is left at 0. */
+        const int N = 2;
+        double data[4] = {1.0, 1.0, 1.0, 1.0};
+        double filt[2] = {0.0, 0.0};
+        double *filt_ptr[1] = {filt};
+        xtract_mel_filter mf;
+        double result[1] = {-1.0};
+
+        mf.n_filters = 1;
+        mf.filters = filt_ptr;
+        REQUIRE(xtract_mmbses(data, N, &mf, result) == XTRACT_SUCCESS);
+        REQUIRE(result[0] == Approx(0.0).margin(EPSILON));
+    }
+
+    SECTION("a single passed bin reduces to log of its scaled magnitude")
+    {
+        /* Only bin 0 passes (count == 1). Its magnitude is |3 + 4i| = 5, the
+         * energy is 5/N = 2.5, and the coefficient is log(2*pi*2.5). */
+        const int N = 2;
+        double data[4] = {3.0, 4.0, 9.0, 9.0};
+        double filt[2] = {1.0, 0.0};
+        double *filt_ptr[1] = {filt};
+        xtract_mel_filter mf;
+        double result[1] = {-1.0};
+
+        mf.n_filters = 1;
+        mf.filters = filt_ptr;
+        REQUIRE(xtract_mmbses(data, N, &mf, result) == XTRACT_SUCCESS);
+        REQUIRE(result[0] == Approx(log(2.0 * M_PI * 2.5)).epsilon(EPSILON));
+    }
+
+    SECTION("a single passed bin with zero magnitude hits the log floor")
+    {
+        /* count == 1 but the bin is silent, so the scaled energy is below the
+         * log limit and the floored value is returned. */
+        const int N = 2;
+        double data[4] = {0.0, 0.0, 5.0, 5.0};
+        double filt[2] = {1.0, 0.0};
+        double *filt_ptr[1] = {filt};
+        xtract_mel_filter mf;
+        double result[1] = {-1.0};
+
+        mf.n_filters = 1;
+        mf.filters = filt_ptr;
+        REQUIRE(xtract_mmbses(data, N, &mf, result) == XTRACT_SUCCESS);
+        REQUIRE(result[0] == Approx(LOG_LIMIT_DB).epsilon(EPSILON));
+    }
+
+    SECTION("two passed bins with no imaginary spread floor the covariance term")
+    {
+        /* count == 2, real parts {1, -1}, imaginary parts {0, 0}. The imaginary
+         * variance is 0 so the determinant term is 0 (floored to -96), while the
+         * energy term is log(2*pi*1.0). Result is the mean of the two. */
+        const int N = 2;
+        double data[4] = {1.0, 0.0, -1.0, 0.0};
+        double filt[2] = {1.0, 1.0};
+        double *filt_ptr[1] = {filt};
+        xtract_mel_filter mf;
+        double result[1] = {-1.0};
+
+        mf.n_filters = 1;
+        mf.filters = filt_ptr;
+        REQUIRE(xtract_mmbses(data, N, &mf, result) == XTRACT_SUCCESS);
+        REQUIRE(result[0] == Approx((log(2.0 * M_PI * 1.0) + LOG_LIMIT_DB) / 2.0).epsilon(EPSILON));
+    }
+
+    SECTION("three passed bins exercise the full covariance path")
+    {
+        /* count == 3. real = {1, 0, -1}, imag = {0, 1, -1}; both means are 0.
+         * realVar = imagVar = 2/3 (divided by count), covariance = 1/(count-1)
+         * = 0.5, so the determinant term is (2/3)(2/3) - 0.5^2 = 7/36.
+         * energy = (1 + 1 + sqrt(2)) / 3 mean magnitude, scaled by 2*pi.
+         * Result is the mean of log(energy) and log(7/36). */
+        const int N = 3;
+        double data[6] = {1.0, 0.0, 0.0, 1.0, -1.0, -1.0};
+        double filt[3] = {1.0, 1.0, 1.0};
+        double *filt_ptr[1] = {filt};
+        xtract_mel_filter mf;
+        double result[1] = {-1.0};
+        double energy = 2.0 * M_PI * (2.0 + sqrt(2.0)) / 3.0;
+        double determinant = 7.0 / 36.0;
+        double expected = (log(energy) + log(determinant)) / 2.0;
+
+        mf.n_filters = 1;
+        mf.filters = filt_ptr;
+        REQUIRE(xtract_mmbses(data, N, &mf, result) == XTRACT_SUCCESS);
+        REQUIRE(result[0] == Approx(expected).epsilon(EPSILON));
+    }
+}


### PR DESCRIPTION
PR 3 of roadmap milestone 1.1, item 3 (Test Coverage Baseline). Covers previously-untested feature functions in `scalar.c` and `vector.c`.

New tests (hand-derived expected values, Catch style):
- **`xtract_tristimulus_1` / `_2` / `_3`** (`xttest_scalar.cpp`) — a shared six-harmonic spectrum (amplitudes {4,3,2,1,5,2} of a 100 Hz fundamental) partitions energy into bands h=1, h∈{2,3,4}, h≥5, giving 4/17, 6/17, 7/17. Each also has a no-result case (empty band).
- **`xtract_spectral_inharmonicity`** — perfectly harmonic spectrum → 0; a 5 Hz-sharp second partial → 0.05; plus zero-fundamental and all-zero-amplitude no-result paths.
- **`xtract_peak`** — last-sample peak detector: success, last-sample-not-maximum, and below-threshold no-result paths.
- **`xtract_mmbses`** (`xttest_vector.cpp`) — all branches: empty filter (count 0), single passed bin (count 1, both the normal `log(2*pi*energy)` and the log-floor path), and the multi-bin covariance path including the determinant log-floor and the full count≥3 case.

Scope note: `failsafe_f0` was originally slated for this PR but moved to the f0/lifecycle PR, since its fallback path drives `xtract_spectrum`/`xtract_peak_spectrum` and belongs with the FFT-dependent tests.

## Coverage impact (`make coverage`, first-party)

| File | Before | After |
|---|---|---|
| scalar.c | 73.5% / 84.4% | **88.6% / 95.6%** (lines / functions) |
| vector.c | 67.5% / 95.0% | **78.8% / 100%** |

`make check` passes: **549 assertions in 79 test cases** (up from 515/73 on main).