### PR TITLE
feat: add descriptor system and dispatch table tests

### DIFF
--- a/tests/xttest_descriptors.cpp
+++ b/tests/xttest_descriptors.cpp
@@ -1,0 +1,68 @@
+
+#define _USE_MATH_DEFINES
+#include <cmath>
+
+#include "catch.hpp"
+
+#include "xtract/libxtract.h"
+
+/*
+ * Unit tests for the descriptor system (xtract_make_descriptors /
+ * xtract_free_descriptors) and the xtract[] feature dispatch table.
+ *
+ * A single xtract_make_descriptors() call populates a descriptor for every
+ * feature via one large switch, so iterating the returned array exercises that
+ * switch and lets us check the cross-feature invariants.
+ */
+
+static const double EPSILON = 1e-10;
+
+TEST_CASE("xtract_make_descriptors and xtract_free_descriptors", "[descriptors]")
+{
+    xtract_function_descriptor_t *fd = xtract_make_descriptors();
+    REQUIRE(fd != nullptr);
+
+    SECTION("every descriptor's id matches its feature index")
+    {
+        for (int f = 0; f < XTRACT_FEATURES; f++)
+            REQUIRE(fd[f].id == f);
+    }
+
+    SECTION("scalar/vector classification is set correctly")
+    {
+        /* mean reduces to a single value; spectrum produces a vector. */
+        REQUIRE(fd[XTRACT_MEAN].is_scalar == XTRACT_TRUE);
+        REQUIRE(fd[XTRACT_SPECTRUM].is_scalar == XTRACT_FALSE);
+    }
+
+    REQUIRE(xtract_free_descriptors(fd) == XTRACT_SUCCESS);
+}
+
+TEST_CASE("xtract_free_descriptors accepts NULL", "[descriptors]")
+{
+    REQUIRE(xtract_free_descriptors(nullptr) == XTRACT_SUCCESS);
+}
+
+TEST_CASE("xtract[] dispatch table", "[dispatch]")
+{
+    SECTION("every feature slot points to a function")
+    {
+        for (int f = 0; f < XTRACT_FEATURES; f++)
+            REQUIRE(xtract[f] != nullptr);
+    }
+
+    SECTION("slots map to the expected function")
+    {
+        /* Verifies the table is ordered consistently with the feature enum,
+         * catching the copy-paste/ordering errors a flat pointer table invites.
+         * sum and mean share input but must give different results. */
+        double data[] = {2.0, 4.0, 6.0, 8.0};
+        double result = -1.0;
+
+        REQUIRE(xtract[XTRACT_MEAN](data, 4, NULL, &result) == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(5.0).epsilon(EPSILON));
+
+        REQUIRE(xtract[XTRACT_SUM](data, 4, NULL, &result) == XTRACT_SUCCESS);
+        REQUIRE(result == Approx(20.0).epsilon(EPSILON));
+    }
+}


### PR DESCRIPTION
PR 6 (final) of roadmap milestone 1.1, item 3 (Test Coverage Baseline). Covers the descriptor system and the `xtract[]` dispatch table — the last items in the roadmap's stated priority order — in a new `tests/xttest_descriptors.cpp`.

- **`xtract_make_descriptors`** — one call populates a descriptor for every feature through a single ~1500-line switch, so iterating the returned array exercises that switch. Asserts the cross-feature invariant `fd[f].id == f` for all features, plus scalar/vector classification spot checks (`mean` is scalar, `spectrum` is not).
- **`xtract_free_descriptors`** — success path and the `NULL` path.
- **`xtract[]` dispatch table** — every feature slot is non-NULL, and a mapping spot check (`xtract[XTRACT_MEAN]` → 5.0, `xtract[XTRACT_SUM]` → 20.0 on shared input) confirms the flat pointer table is ordered consistently with the feature enum.

## Coverage impact (`make coverage`, first-party)

| File | Before | After |
|---|---|---|
| descriptors.c | 0% (untested) | **99.1% / 100%** (lines / functions) |

(The ~0.9% residual is the `malloc`-failure branch.)

This completes item 3. With all six test PRs (#161–#166) merged, every first-party function is exercised and `descriptors.c` — the largest single source file — goes from untested to near-complete.

`make check` passes: **771 assertions in 96 test cases**.