### PR TITLE
refactor: replace pow() with multiplication for integer orders in xtract_lnorm

### DIFF
--- a/src/delta.c
+++ b/src/delta.c
@@ -27,6 +27,24 @@
 #include <stdlib.h>
 #include "xtract/libxtract.h"
 
+/* Direct multiplication for the common small integer orders, avoiding pow()'s
+ * exp(order * log(base)) dispatch in the inner loop. base is non-negative. */
+static double xtract_pow_order(const double base, const double order)
+{
+    if(order == 2.0)
+        return base * base;
+    if(order == 1.0)
+        return base;
+    if(order == 3.0)
+        return base * base * base;
+    if(order == 4.0)
+    {
+        const double b2 = base * base;
+        return b2 * b2;
+    }
+    return pow(base, order);
+}
+
 int xtract_flux(const double *data, const int N, const void *argv , double *result)
 {
 
@@ -77,7 +95,7 @@ int xtract_lnorm(const double *data, const int N, const void *argv , double *res
         {
             if(data[n] > 0)
             {
-                *result += pow(data[n], order);
+                *result += xtract_pow_order(data[n], order);
                 ++k;
             }
         }
@@ -85,14 +103,23 @@ int xtract_lnorm(const double *data, const int N, const void *argv , double *res
     default:
         for(n = 0; n < N; n++)
         {
-            *result += pow(fabs(data[n]), order);
+            *result += xtract_pow_order(fabs(data[n]), order);
             ++k;
         }
         break;
 
     }
 
-    *result = pow(*result, 1.0 / order);
+    /* integer-order roots without pow(): sqrt for 2, cbrt for 3, sqrt(sqrt)
+     * for 4; order 1 needs no root (the sum is already the 1-norm) */
+    if(order == 2.0)
+        *result = sqrt(*result);
+    else if(order == 3.0)
+        *result = cbrt(*result);
+    else if(order == 4.0)
+        *result = sqrt(sqrt(*result));
+    else if(order != 1.0)
+        *result = pow(*result, 1.0 / order);
     
     if (k == 0)
     {


### PR DESCRIPTION
Performance Pass (roadmap milestone 1.1, item 2): "Replace `pow()` with multiplications for known integer orders".

`xtract_lnorm` called `pow(fabs(data[n]), order)` in its inner loop and `pow(result, 1.0/order)` for the final root. For the common small integer orders (1–4) `pow()` is far more expensive than direct multiplication (it dispatches through `exp(order * log(x))`), and it dominated the loop.

Adds a small `xtract_pow_order` helper that uses direct multiplication for orders 1–4 and falls back to `pow()` otherwise, and replaces the final root with `sqrt`/`cbrt`/`sqrt(sqrt(...))` for orders 2/3/4 (order 1 needs no root), falling back to `pow()` for other orders. Behaviour is unchanged — results are identical within tolerance (and `x*x` is if anything slightly more accurate than `pow(x, 2.0)`).

## Measurement (`make bench`, vDSP, min of 8 full-suite runs)

| benchmark | before | after | speedup |
|---|---|---|---|
| lnorm.N512 | 2.263µs | 0.278µs | **8.1×** |
| lnorm.N4096 | 18.468µs | 2.254µs | **8.2×** |

Benchmarked at order = 2 (the common case). Well above the pass's 10% keep threshold. `xtract_flux`, which cascades through `xtract_lnorm`, benefits too.

`make check` passes (240 tests) and `make analyze` is clean.