### PR TITLE
refactor: add vDSP paths for spectral variance, skewness, and kurtosis

### DIFF
--- a/src/scalar.c
+++ b/src/scalar.c
@@ -232,23 +232,34 @@ int xtract_spectral_mean(const double *data, const int N, const void *argv, doub
 int xtract_spectral_variance(const double *data, const int N, const void *argv, double *result)
 {
 
-    int m;
+    const int m = N >> 1;
     double A = 0.0;
-    const double *freqs, *amps;
+    const double *amps = data;
+    const double *freqs = data + m;
     const double arg0 = *(double *)argv;
 
-    m = N >> 1;
+#ifdef __APPLE__
+    double neg_c = -arg0;
+    double *d = (double *)malloc(m * sizeof(double));
+    if(d == NULL)
+        return XTRACT_MALLOC_FAILED;
 
-    amps = data;
-    freqs = data + m;
+    vDSP_vsaddD(freqs, 1, &neg_c, d, 1, m);  /* d = freqs - centroid */
+    vDSP_vsqD(d, 1, d, 1, m);                 /* d = (freqs - centroid)^2 */
+    vDSP_dotprD(d, 1, amps, 1, result, m);    /* sum(d * amps) */
+    vDSP_sveD(amps, 1, &A, m);                /* sum(amps) */
+    free(d);
+#else
+    int mm = m;
 
     *result = 0.0;
 
-    while(m--)
+    while(mm--)
     {
-        A += amps[m];
-        *result += XTRACT_SQ(freqs[m] - arg0) * amps[m];
+        A += amps[mm];
+        *result += XTRACT_SQ(freqs[mm] - arg0) * amps[mm];
     }
+#endif
 
     if (A == 0.0)
     {
@@ -271,11 +282,18 @@ int xtract_spectral_standard_deviation(const double *data, const int N, const vo
 int xtract_spectral_skewness(const double *data, const int N, const void *argv,  double *result)
 {
 
-    int m;
-    const double *freqs, *amps;
+    const int m = N >> 1;
+    const double *amps = data;
+    const double *freqs = data + m;
     const double arg0 = ((double *)argv)[0];
     const double arg1 = ((double *)argv)[1];
     double sum_amps = 0.0;
+#ifdef __APPLE__
+    double neg_c = -arg0;
+    double *d, *t;
+#else
+    int mm = m;
+#endif
 
     *result = 0.0;
 
@@ -284,16 +302,24 @@ int xtract_spectral_skewness(const double *data, const int N, const void *argv, 
         return XTRACT_NO_RESULT;
     }
 
-    m = N >> 1;
-
-    amps = data;
-    freqs = data + m;
-
-    while(m--)
+#ifdef __APPLE__
+    d = (double *)malloc(2 * (size_t)m * sizeof(double));
+    if(d == NULL)
+        return XTRACT_MALLOC_FAILED;
+    t = d + m;
+    vDSP_vsaddD(freqs, 1, &neg_c, d, 1, m);  /* d = freqs - centroid */
+    vDSP_vmulD(d, 1, d, 1, t, 1, m);          /* t = d^2 */
+    vDSP_vmulD(t, 1, d, 1, t, 1, m);          /* t = d^3 */
+    vDSP_dotprD(t, 1, amps, 1, result, m);    /* sum(d^3 * amps) */
+    vDSP_sveD(amps, 1, &sum_amps, m);
+    free(d);
+#else
+    while(mm--)
     {
-        *result += XTRACT_POW3(freqs[m] - arg0) * amps[m];
-        sum_amps += amps[m];
+        *result += XTRACT_POW3(freqs[mm] - arg0) * amps[mm];
+        sum_amps += amps[mm];
     }
+#endif
 
     if(sum_amps == 0.0)
     {
@@ -309,30 +335,44 @@ int xtract_spectral_skewness(const double *data, const int N, const void *argv, 
 int xtract_spectral_kurtosis(const double *data, const int N, const void *argv,  double *result)
 {
 
-    int m;
-    const double *freqs, *amps;
+    const int m = N >> 1;
+    const double *amps = data;
+    const double *freqs = data + m;
     const double arg0 = ((double *)argv)[0];
     const double arg1 = ((double *)argv)[1];
     double sum_amps = 0.0;
+#ifdef __APPLE__
+    double neg_c = -arg0;
+    double *d;
+#else
+    int mm = m;
+#endif
 
-    if (((double *)argv)[1] == 0.0)
+    if (arg1 == 0.0)
     {
         *result = 0.0;
         return XTRACT_NO_RESULT;
     }
 
-    m = N >> 1;
-
-    amps = data;
-    freqs = data + m;
-
     *result = 0.0;
 
-    while(m--)
+#ifdef __APPLE__
+    d = (double *)malloc((size_t)m * sizeof(double));
+    if(d == NULL)
+        return XTRACT_MALLOC_FAILED;
+    vDSP_vsaddD(freqs, 1, &neg_c, d, 1, m);  /* d = freqs - centroid */
+    vDSP_vsqD(d, 1, d, 1, m);                 /* d = d^2 */
+    vDSP_vsqD(d, 1, d, 1, m);                 /* d = d^4 */
+    vDSP_dotprD(d, 1, amps, 1, result, m);    /* sum(d^4 * amps) */
+    vDSP_sveD(amps, 1, &sum_amps, m);
+    free(d);
+#else
+    while(mm--)
     {
-        *result += XTRACT_POW4(freqs[m] - arg0) * amps[m];
-        sum_amps += amps[m];
+        *result += XTRACT_POW4(freqs[mm] - arg0) * amps[mm];
+        sum_amps += amps[mm];
     }
+#endif
 
     if(sum_amps == 0.0)
     {


### PR DESCRIPTION
Performance Pass (roadmap milestone 1.1, item 2): "Extend vDSP coverage to remaining spectral moments".

`xtract_spectral_centroid` already had a vDSP path; the closely related `xtract_spectral_variance`, `xtract_spectral_skewness`, and `xtract_spectral_kurtosis` were still scalar loops on macOS. Each now has an `#ifdef __APPLE__` vDSP path:
- subtract the centroid (`vDSP_vsaddD`), raise to the appropriate power (`vDSP_vsqD`/`vDSP_vmulD`), then weight-and-sum against the amplitudes (`vDSP_dotprD`), with `vDSP_sveD` for the amplitude sum.
- The numerically-stable "subtract-centroid then power" form is kept (the buffer-free `E[x²]−E[x]²`-style expansion would suffer cancellation when the centroid is large), so each needs a scratch buffer — variance/kurtosis one of length N/2, skewness two (for d³). The scalar `#else` path is unchanged.

## Measurement (`make bench`, vDSP, min of 8 full-suite runs)

| benchmark | scalar | vDSP | gain |
|---|---|---|---|
| spectral_variance.N4096 | 1.670µs | 0.966µs | **+42%** |
| spectral_variance.N512 | 0.185µs | 0.131µs | +29% |
| spectral_skewness.N4096 | 1.677µs | 1.204µs | **+28%** |
| spectral_skewness.N512 | 0.190µs | 0.153µs | +19% |
| spectral_kurtosis.N4096 | 1.651µs | 1.100µs | **+33%** |
| spectral_kurtosis.N512 | 0.185µs | 0.149µs | +19% |

All cases clear the pass's 10% keep threshold (even with the scratch `malloc`, which I measured first as the probe). `make check` passes (240 tests); `make analyze` clean.

Note: these three now allocate per call on the vDSP path (they didn't before). That's consistent with the existing `variance`/`average_deviation` vDSP paths and is captured in the roadmap's real-time-safety note (resolved properly by the 2.0 context API).