### PR TITLE
refactor: vectorise scalar reduction loops via omp simd reduction

### DIFF
--- a/src/Make.config
+++ b/src/Make.config
@@ -8,7 +8,9 @@ ifeq ($(PLATFORM), Darwin)
     # clang-only: warn when a variable may be read uninitialised on some paths
     FLAGS += -Wconditional-uninitialized
 else
-    FLAGS += -DUSE_OOURA
+    # -fopenmp-simd enables the #pragma omp simd reduction hints in the scalar
+    # paths (the macOS paths use vDSP instead). SIMD subset only, no runtime.
+    FLAGS += -DUSE_OOURA -fopenmp-simd
 endif
 
 # Unused for the static archive, but a shared library must link the

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -51,14 +51,14 @@ int xtract_mean(const double *data, const int N, const void *argv, double *resul
 #ifdef __APPLE__
     vDSP_meanvD(data, 1, result, N);
 #else
-    int n = N;
+    int n;
+    double sum = 0.0;
 
-    *result = 0.0;
+    #pragma omp simd reduction(+:sum)
+    for(n = 0; n < N; n++)
+        sum += data[n];
 
-    while(n--)
-        *result += data[n];
-
-    *result /= N;
+    *result = sum / N;
 #endif
 
     return XTRACT_SUCCESS;
@@ -81,15 +81,15 @@ int xtract_variance(const double *data, const int N, const void *argv, double *r
     *result *= (double)N / (N - 1); /* Bessel correction */
     free(shifted);
 #else
-    int n = N;
+    int n;
     const double arg0 = *(double *)argv;
+    double sum = 0.0;
 
-    *result = 0.0;
+    #pragma omp simd reduction(+:sum)
+    for(n = 0; n < N; n++)
+        sum += XTRACT_SQ(data[n] - arg0);
 
-    while(n--)
-        *result += XTRACT_SQ(data[n] - arg0);
-
-    *result /= (N - 1);
+    *result = sum / (N - 1);
 #endif
 
     return XTRACT_SUCCESS;
@@ -121,15 +121,15 @@ int xtract_average_deviation(const double *data, const int N, const void *argv, 
     vDSP_meanvD(temp, 1, result, N);
     free(temp);
 #else
-    int n = N;
+    int n;
     const double arg0 = *(double *)argv;
+    double sum = 0.0;
 
-    *result = 0.0;
+    #pragma omp simd reduction(+:sum)
+    for(n = 0; n < N; n++)
+        sum += fabs(data[n] - arg0);
 
-    while(n--)
-        *result += fabs(data[n] - arg0);
-
-    *result /= N;
+    *result = sum / N;
 #endif
 
     return XTRACT_SUCCESS;
@@ -195,22 +195,22 @@ int xtract_kurtosis(const double *data, const int N, const void *argv,  double *
 int xtract_spectral_centroid(const double *data, const int N, const void *argv,  double *result)
 {
 
-    int n = (N >> 1);
-
-    const double *freqs, *amps;
+    const int n = (N >> 1);
+    const double *amps = data;
+    const double *freqs = data + n;
     double FA = 0.0, A = 0.0;
-
-    amps = data;
-    freqs = data + n;
 
 #ifdef __APPLE__
     vDSP_dotprD(amps, 1, freqs, 1, &FA, n);
     vDSP_sveD(amps, 1, &A, n);
 #else
-    while(n--)
+    int m;
+
+    #pragma omp simd reduction(+:FA,A)
+    for(m = 0; m < n; m++)
     {
-        FA += freqs[n] * amps[n];
-        A += amps[n];
+        FA += freqs[m] * amps[m];
+        A += amps[m];
     }
 #endif
 
@@ -755,13 +755,14 @@ int xtract_rms_amplitude(const double *data, const int N, const void *argv, doub
 #ifdef __APPLE__
     vDSP_rmsqvD(data, 1, result, N);
 #else
-    int n = N;
+    int n;
+    double sum = 0.0;
 
-    *result = 0.0;
+    #pragma omp simd reduction(+:sum)
+    for(n = 0; n < N; n++)
+        sum += XTRACT_SQ(data[n]);
 
-    while(n--) *result += XTRACT_SQ(data[n]);
-
-    *result = sqrt(*result / (double)N);
+    *result = sqrt(sum / (double)N);
 #endif
 
     return XTRACT_SUCCESS;
@@ -990,12 +991,14 @@ int xtract_sum(const double *data, const int N, const void *argv, double *result
 #ifdef __APPLE__
     vDSP_sveD(data, 1, result, N);
 #else
-    int n = N;
+    int n;
+    double sum = 0.0;
 
-    *result = 0.0;
+    #pragma omp simd reduction(+:sum)
+    for(n = 0; n < N; n++)
+        sum += data[n];
 
-    while(n--)
-        *result += *data++;
+    *result = sum;
 #endif
 
     return XTRACT_SUCCESS;

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -250,15 +250,17 @@ int xtract_spectral_variance(const double *data, const int N, const void *argv, 
     vDSP_sveD(amps, 1, &A, m);                /* sum(amps) */
     free(d);
 #else
-    int mm = m;
+    int mm;
+    double sum = 0.0;
 
-    *result = 0.0;
-
-    while(mm--)
+    #pragma omp simd reduction(+:A,sum)
+    for(mm = 0; mm < m; mm++)
     {
         A += amps[mm];
-        *result += XTRACT_SQ(freqs[mm] - arg0) * amps[mm];
+        sum += XTRACT_SQ(freqs[mm] - arg0) * amps[mm];
     }
+
+    *result = sum;
 #endif
 
     if (A == 0.0)
@@ -292,7 +294,8 @@ int xtract_spectral_skewness(const double *data, const int N, const void *argv, 
     double neg_c = -arg0;
     double *d, *t;
 #else
-    int mm = m;
+    int mm;
+    double sum = 0.0;
 #endif
 
     *result = 0.0;
@@ -314,11 +317,14 @@ int xtract_spectral_skewness(const double *data, const int N, const void *argv, 
     vDSP_sveD(amps, 1, &sum_amps, m);
     free(d);
 #else
-    while(mm--)
+    #pragma omp simd reduction(+:sum,sum_amps)
+    for(mm = 0; mm < m; mm++)
     {
-        *result += XTRACT_POW3(freqs[mm] - arg0) * amps[mm];
+        sum += XTRACT_POW3(freqs[mm] - arg0) * amps[mm];
         sum_amps += amps[mm];
     }
+
+    *result = sum;
 #endif
 
     if(sum_amps == 0.0)
@@ -345,7 +351,8 @@ int xtract_spectral_kurtosis(const double *data, const int N, const void *argv, 
     double neg_c = -arg0;
     double *d;
 #else
-    int mm = m;
+    int mm;
+    double sum = 0.0;
 #endif
 
     if (arg1 == 0.0)
@@ -367,11 +374,14 @@ int xtract_spectral_kurtosis(const double *data, const int N, const void *argv, 
     vDSP_sveD(amps, 1, &sum_amps, m);
     free(d);
 #else
-    while(mm--)
+    #pragma omp simd reduction(+:sum,sum_amps)
+    for(mm = 0; mm < m; mm++)
     {
-        *result += XTRACT_POW4(freqs[mm] - arg0) * amps[mm];
+        sum += XTRACT_POW4(freqs[mm] - arg0) * amps[mm];
         sum_amps += amps[mm];
     }
+
+    *result = sum;
 #endif
 
     if(sum_amps == 0.0)


### PR DESCRIPTION
Performance Pass (roadmap milestone 1.1, item 2): reduction reassociation.

The scalar (`#else`, non-Apple) reduction loops in `scalar.c` were serial floating-point accumulations, which strict IEEE ordering prevents the compiler from autovectorising at `-O3`. Adding a one-line `#pragma omp simd reduction(...)` to each (with `-fopenmp-simd` on the non-Apple build) lets the compiler emit a vectorised reduction — portably across SSE/AVX/NEON.

**Functions vectorised (their `#else` paths):** `mean`, `sum`, `variance`, `average_deviation`, `rms_amplitude`, `spectral_centroid`, `spectral_variance`, `spectral_skewness`, `spectral_kurtosis`. macOS paths are unchanged (they already use vDSP, and `#else` isn't compiled there).

## Measurement (x86 Linux, disposable interleaved A/B, min of 15)
~2× on every vectorised function (N512 / N4096):

| function | gain |
|---|---|
| mean | +47% / +50% |
| sum | +47% / +50% |
| variance | +47% / +50% |
| average_deviation | +47% / +50% |
| spectral_centroid | +44% / +50% |
| spectral_variance | +44% / +50% |
| spectral_skewness | +43% / +50% |
| spectral_kurtosis | +43% / +49% |

Each was measured before inclusion; control functions left unpragma'd stayed at ~0%. Compute-bound functions were deliberately excluded: the *time-domain* `skewness`/`kurtosis` have a per-element divide and measured ~0%, and `loudness`/`flatness` (transcendentals) and `rolloff`/`tristimulus` (conditionals/early-break) don't fit the pattern. (The *spectral* skew/kurtosis, by contrast, have no per-element divide and do benefit.)

## Safety
- The pragma is a **no-op without `-fopenmp-simd`**, so it can't change behaviour on toolchains lacking it.
- `-fopenmp-simd` is the SIMD-only subset of OpenMP — **no runtime dependency** — added only to the non-Apple build.
- Unlike `-ffast-math`, it does **not** relax NaN/Inf/denormal semantics, so the `XTRACT_NO_RESULT`-on-NaN guards are untouched.
- The reordered summation differs by ~1 ULP; the test suite's tolerances absorb it (240 tests pass with the flag, validated on the Linux CI).

`make`, `make check`, `make analyze` pass on macOS (where these `#else` paths aren't compiled); CI validates the vectorised paths on Linux and Windows/MinGW.