### PR TITLE
chore: fuzz all feature functions (scalar/delta/vector) and fix double->int UB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,22 @@ jobs:
           export JAVA_HOME="$(cygpath -u "$JAVA_HOME")"
           export PATH="${JAVA_HOME}/bin:${PATH}"
           PYTHON=python NODE_INCLUDE=/mingw64/include/node make -C swig check
+
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install clang (provides libFuzzer)
+        run: sudo apt-get update && sudo apt-get install -y clang
+
+      - name: Fuzz scalar features (libFuzzer, ASan + UBSan)
+        run: make fuzz FUZZ_TIME=60
+
+      - name: Upload crash reproducer on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crash
+          path: fuzz/crash-*
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Install clang (provides libFuzzer)
         run: sudo apt-get update && sudo apt-get install -y clang
 
-      - name: Fuzz scalar features (libFuzzer, ASan + UBSan)
+      - name: Fuzz feature functions (libFuzzer, ASan + UBSan)
         run: make fuzz FUZZ_TIME=60
 
       - name: Upload crash reproducer on failure

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ dist
 coverage.info
 coverage-html
 
+# Fuzzing (make fuzz)
+fuzz/xtfuzz
+fuzz/crash-*
+fuzz/*.dSYM
+
 # Project-specific files
 examples/simpletest/simpletest
 tests/xttest

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ coverage.info
 coverage-html
 
 # Fuzzing (make fuzz)
-fuzz/xtfuzz
+fuzz/xtfuzz_*
 fuzz/crash-*
 fuzz/*.dSYM
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HPATH = include/xtract
 
 export XTRACT_VERSION PREFIX LIBRARY
 
-.PHONY: examples clean install doc src swig bench analyze check-asan cppcheck coverage
+.PHONY: examples clean install doc src swig bench analyze check-asan cppcheck coverage fuzz
 
 all: src examples
 
@@ -72,6 +72,27 @@ coverage:
 	@echo "Coverage report written to coverage-html/index.html"
 	@$(MAKE) -C src clean
 	@$(MAKE) -C tests clean
+	@$(MAKE) -C src
+
+# Build the library and a libFuzzer harness with fuzzer coverage + ASan/UBSan
+# and run it for FUZZ_TIME seconds. Requires a clang with libFuzzer: Apple clang
+# lacks the runtime, so on macOS install LLVM via Homebrew and pass
+# FUZZ_CC=/opt/homebrew/opt/llvm/bin/clang. Cleans before and restores the
+# normal build after a clean run.
+FUZZ_CC ?= clang
+FUZZ_TIME ?= 60
+# Sanitizer set for the fuzz build. AddressSanitizer's runtime deadlocks during
+# init on some macOS toolchains; pass FUZZ_SAN=undefined to fuzz with UBSan only
+# there. CI runs the full set on Linux.
+FUZZ_SAN ?= address,undefined
+FUZZ_LIB_FLAGS = -fsanitize=fuzzer-no-link,$(FUZZ_SAN) -fno-sanitize-recover=all -g -O1
+fuzz:
+	@$(MAKE) -C src clean
+	@$(MAKE) -C src CC=$(FUZZ_CC) EXTRA_FLAGS="$(FUZZ_LIB_FLAGS)"
+	@$(MAKE) -C fuzz FUZZ_CC=$(FUZZ_CC) FUZZ_SAN=$(FUZZ_SAN)
+	@./fuzz/xtfuzz -max_total_time=$(FUZZ_TIME) -rss_limit_mb=4096 -artifact_prefix=fuzz/
+	@$(MAKE) -C fuzz clean
+	@$(MAKE) -C src clean
 	@$(MAKE) -C src
 
 bench: src

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,10 @@ coverage:
 	@$(MAKE) -C tests clean
 	@$(MAKE) -C src
 
-# Build the library and a libFuzzer harness with fuzzer coverage + ASan/UBSan
-# and run it for FUZZ_TIME seconds. Requires a clang with libFuzzer: Apple clang
-# lacks the runtime, so on macOS install LLVM via Homebrew and pass
+# Build the library and the libFuzzer harnesses (one per feature header:
+# scalar, delta, vector) with fuzzer coverage + ASan/UBSan and run each for
+# FUZZ_TIME seconds. Requires a clang with libFuzzer: Apple clang lacks the
+# runtime, so on macOS install LLVM via Homebrew and pass
 # FUZZ_CC=/opt/homebrew/opt/llvm/bin/clang. Cleans before and restores the
 # normal build after a clean run.
 FUZZ_CC ?= clang
@@ -90,7 +91,10 @@ fuzz:
 	@$(MAKE) -C src clean
 	@$(MAKE) -C src CC=$(FUZZ_CC) EXTRA_FLAGS="$(FUZZ_LIB_FLAGS)"
 	@$(MAKE) -C fuzz FUZZ_CC=$(FUZZ_CC) FUZZ_SAN=$(FUZZ_SAN)
-	@./fuzz/xtfuzz -max_total_time=$(FUZZ_TIME) -rss_limit_mb=4096 -artifact_prefix=fuzz/
+	@for h in scalar delta vector; do \
+		echo "=== fuzzing $$h features ($(FUZZ_TIME)s) ==="; \
+		./fuzz/xtfuzz_$$h -max_total_time=$(FUZZ_TIME) -rss_limit_mb=4096 -artifact_prefix=fuzz/ || exit $$?; \
+	done
 	@$(MAKE) -C fuzz clean
 	@$(MAKE) -C src clean
 	@$(MAKE) -C src

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,0 +1,25 @@
+TARGET = xtfuzz
+SRC = fuzz_scalar.c
+
+# A clang with libFuzzer. Apple clang lacks the runtime; on macOS install LLVM
+# via Homebrew and pass FUZZ_CC=/opt/homebrew/opt/llvm/bin/clang.
+FUZZ_CC ?= clang
+FUZZ_SAN ?= address,undefined
+SANITIZE = -fsanitize=fuzzer,$(FUZZ_SAN) -fno-sanitize-recover=all -g -O1
+CFLAGS = -I../include $(SANITIZE)
+
+LIBS =
+OS := $(shell uname)
+ifeq ($(OS), Darwin)
+    LIBS += -framework Accelerate
+endif
+LIBS += -lm
+
+$(TARGET): $(SRC) ../src/libxtract.a
+	$(FUZZ_CC) $(CFLAGS) -o $@ $(SRC) ../src/libxtract.a $(LIBS)
+
+clean:
+	@$(RM) $(TARGET)
+	@$(RM) -r $(TARGET).dSYM
+
+.PHONY: clean

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,5 +1,4 @@
-TARGET = xtfuzz
-SRC = fuzz_scalar.c
+TARGETS = xtfuzz_scalar xtfuzz_delta xtfuzz_vector
 
 # A clang with libFuzzer. Apple clang lacks the runtime; on macOS install LLVM
 # via Homebrew and pass FUZZ_CC=/opt/homebrew/opt/llvm/bin/clang.
@@ -15,11 +14,13 @@ ifeq ($(OS), Darwin)
 endif
 LIBS += -lm
 
-$(TARGET): $(SRC) ../src/libxtract.a
-	$(FUZZ_CC) $(CFLAGS) -o $@ $(SRC) ../src/libxtract.a $(LIBS)
+all: $(TARGETS)
+
+xtfuzz_%: fuzz_%.c ../src/libxtract.a
+	$(FUZZ_CC) $(CFLAGS) -o $@ $< ../src/libxtract.a $(LIBS)
 
 clean:
-	@$(RM) $(TARGET)
-	@$(RM) -r $(TARGET).dSYM
+	@$(RM) $(TARGETS)
+	@$(RM) -r $(addsuffix .dSYM,$(TARGETS))
 
-.PHONY: clean
+.PHONY: all clean

--- a/fuzz/fuzz_delta.c
+++ b/fuzz/fuzz_delta.c
@@ -1,0 +1,73 @@
+/*
+ * libFuzzer harness for the delta (time-derivative) feature functions
+ * (xtract_delta.h): flux, lnorm, attack_time, decay_time, difference_vector.
+ *
+ * All share the uniform signature and take a plain double / NULL argv with no
+ * setup, so one harness drives them via the xtract[] dispatch table. The
+ * fuzzer's bytes become a feature selector, an argv buffer, and the input
+ * vector. Run under AddressSanitizer + UBSan.
+ *
+ * Build/run: make fuzz   (see fuzz/Makefile)
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "xtract/libxtract.h"
+
+static const int eligible[] = {
+    XTRACT_FLUX, XTRACT_LNORM, XTRACT_ATTACK_TIME,
+    XTRACT_DECAY_TIME, XTRACT_DIFFERENCE_VECTOR
+};
+
+#define N_ELIGIBLE ((int)(sizeof(eligible) / sizeof(eligible[0])))
+#define MAX_N 4096
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    int feature;
+    int n;
+    double argv[XTRACT_MAXARGS];
+    double *in;
+    double *result;
+    size_t argv_bytes;
+
+    if (size < 1)
+        return 0;
+
+    feature = eligible[data[0] % N_ELIGIBLE];
+    data++;
+    size--;
+
+    memset(argv, 0, sizeof(argv));
+    argv_bytes = size < sizeof(argv) ? size : sizeof(argv);
+    memcpy(argv, data, argv_bytes);
+    data += argv_bytes;
+    size -= argv_bytes;
+
+    n = (int)(size / sizeof(double));
+    if (n < 1)
+        return 0;
+    if (n > MAX_N)
+        n = MAX_N;
+
+    in = (double *)malloc((size_t)n * sizeof(double));
+    /* difference_vector writes N/2 values; the others write one. Over-allocate
+     * so a harness mis-sizing can't masquerade as an overflow. */
+    result = (double *)calloc((size_t)n + 64, sizeof(double));
+    if (in == NULL || result == NULL)
+    {
+        free(in);
+        free(result);
+        return 0;
+    }
+    memcpy(in, data, (size_t)n * sizeof(double));
+
+    (void)xtract[feature](in, n, argv, result);
+
+    free(in);
+    free(result);
+    return 0;
+}

--- a/fuzz/fuzz_scalar.c
+++ b/fuzz/fuzz_scalar.c
@@ -1,0 +1,93 @@
+/*
+ * libFuzzer harness for the uniform-signature scalar feature functions.
+ *
+ * Every covered feature has the prototype
+ *     int xtract_f(const double *data, int N, const void *argv, double *result)
+ * so one harness drives them all via the xtract[] dispatch table. The fuzzer's
+ * mutated bytes become a function selector, an argv buffer, and the input
+ * vector — naturally exercising NaN, +/-Inf, denormals, N=1, all-zero, etc.
+ * Run under AddressSanitizer + UBSan to surface divide-by-zero, NaN/Inf
+ * propagation, and out-of-bounds access.
+ *
+ * Only features with a plain double/NULL argv and no FFT/mel/stateful setup are
+ * covered here; FFT- and struct-argv functions need their own harness.
+ *
+ * Build/run: make fuzz   (see fuzz/Makefile)
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "xtract/libxtract.h"
+
+static const int eligible[] = {
+    XTRACT_MEAN, XTRACT_VARIANCE, XTRACT_STANDARD_DEVIATION,
+    XTRACT_AVERAGE_DEVIATION, XTRACT_SKEWNESS, XTRACT_KURTOSIS,
+    XTRACT_SPECTRAL_MEAN, XTRACT_SPECTRAL_VARIANCE,
+    XTRACT_SPECTRAL_STANDARD_DEVIATION, XTRACT_SPECTRAL_SKEWNESS,
+    XTRACT_SPECTRAL_KURTOSIS, XTRACT_SPECTRAL_CENTROID,
+    XTRACT_IRREGULARITY_K, XTRACT_IRREGULARITY_J,
+    XTRACT_TRISTIMULUS_1, XTRACT_TRISTIMULUS_2, XTRACT_TRISTIMULUS_3,
+    XTRACT_SMOOTHNESS, XTRACT_SPREAD, XTRACT_ZCR, XTRACT_ROLLOFF,
+    XTRACT_LOUDNESS, XTRACT_FLATNESS, XTRACT_FLATNESS_DB, XTRACT_TONALITY,
+    XTRACT_CREST, XTRACT_NOISINESS, XTRACT_RMS_AMPLITUDE,
+    XTRACT_SPECTRAL_INHARMONICITY, XTRACT_POWER, XTRACT_ODD_EVEN_RATIO,
+    XTRACT_SHARPNESS, XTRACT_SPECTRAL_SLOPE, XTRACT_LOWEST_VALUE,
+    XTRACT_HIGHEST_VALUE, XTRACT_SUM, XTRACT_NONZERO_COUNT, XTRACT_HPS,
+    XTRACT_F0, XTRACT_MCLEOD_F0, XTRACT_MIDICENT, XTRACT_LNORM, XTRACT_FLUX
+};
+
+#define N_ELIGIBLE ((int)(sizeof(eligible) / sizeof(eligible[0])))
+#define MAX_N 2048   /* bound per-exec cost (f0/mcleod_f0 are O(N^2)) */
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    int feature;
+    int n;
+    double argv[XTRACT_MAXARGS];
+    double *in;
+    double *result;
+    size_t argv_bytes;
+
+    if (size < 1)
+        return 0;
+
+    feature = eligible[data[0] % N_ELIGIBLE];
+    data++;
+    size--;
+
+    /* First bytes (up to XTRACT_MAXARGS doubles) become argv; the rest is the
+     * input vector. Both are copied into aligned buffers so a misaligned read
+     * can't be mistaken for a library bug. */
+    memset(argv, 0, sizeof(argv));
+    argv_bytes = size < sizeof(argv) ? size : sizeof(argv);
+    memcpy(argv, data, argv_bytes);
+    data += argv_bytes;
+    size -= argv_bytes;
+
+    n = (int)(size / sizeof(double));
+    if (n < 1)
+        return 0;
+    if (n > MAX_N)
+        n = MAX_N;
+
+    in = (double *)malloc((size_t)n * sizeof(double));
+    /* Over-allocate the result: covered features write a single value, but the
+     * margin keeps a harness mis-sizing from masquerading as an overflow. */
+    result = (double *)calloc((size_t)n + 64, sizeof(double));
+    if (in == NULL || result == NULL)
+    {
+        free(in);
+        free(result);
+        return 0;
+    }
+    memcpy(in, data, (size_t)n * sizeof(double));
+
+    (void)xtract[feature](in, n, argv, result);
+
+    free(in);
+    free(result);
+    return 0;
+}

--- a/fuzz/fuzz_scalar.c
+++ b/fuzz/fuzz_scalar.c
@@ -1,16 +1,20 @@
 /*
- * libFuzzer harness for the uniform-signature scalar feature functions.
+ * libFuzzer harness for the scalar feature functions (xtract_scalar.h).
  *
- * Every covered feature has the prototype
+ * Every scalar feature has the uniform signature
  *     int xtract_f(const double *data, int N, const void *argv, double *result)
- * so one harness drives them all via the xtract[] dispatch table. The fuzzer's
- * mutated bytes become a function selector, an argv buffer, and the input
- * vector — naturally exercising NaN, +/-Inf, denormals, N=1, all-zero, etc.
- * Run under AddressSanitizer + UBSan to surface divide-by-zero, NaN/Inf
- * propagation, and out-of-bounds access.
+ * and writes a single scalar to result[0]. This harness drives all of them:
+ * the enum-backed features through the xtract[] dispatch table, and peak (the
+ * one feature with no table slot) by direct call.
  *
- * Only features with a plain double/NULL argv and no FFT/mel/stateful setup are
- * covered here; FFT- and struct-argv functions need their own harness.
+ * The fuzzer's bytes become a feature selector, an argv buffer, and the input
+ * vector, so NaN, +/-Inf, denormals, N=1, all-zero, etc. are exercised. Run
+ * under AddressSanitizer + UBSan.
+ *
+ * failsafe_f0 computes a spectrum internally, so it runs at a fixed
+ * power-of-two N with the FFT initialised once; wavelet_f0 runs its detector
+ * at the size its state was built for and needs a non-NULL sample-rate argv.
+ * Every other feature takes a fuzzer-chosen N.
  *
  * Build/run: make fuzz   (see fuzz/Makefile)
  */
@@ -21,8 +25,11 @@
 #include <string.h>
 
 #include "xtract/libxtract.h"
+#include "xtract/xtract_scalar.h"
 
-static const int eligible[] = {
+enum { FFT_N = 1024, WAVELET_N = 2048, MAX_N = 2048 };
+
+static const int enum_features[] = {
     XTRACT_MEAN, XTRACT_VARIANCE, XTRACT_STANDARD_DEVIATION,
     XTRACT_AVERAGE_DEVIATION, XTRACT_SKEWNESS, XTRACT_KURTOSIS,
     XTRACT_SPECTRAL_MEAN, XTRACT_SPECTRAL_VARIANCE,
@@ -36,44 +43,75 @@ static const int eligible[] = {
     XTRACT_SPECTRAL_INHARMONICITY, XTRACT_POWER, XTRACT_ODD_EVEN_RATIO,
     XTRACT_SHARPNESS, XTRACT_SPECTRAL_SLOPE, XTRACT_LOWEST_VALUE,
     XTRACT_HIGHEST_VALUE, XTRACT_SUM, XTRACT_NONZERO_COUNT, XTRACT_HPS,
-    XTRACT_F0, XTRACT_MCLEOD_F0, XTRACT_MIDICENT, XTRACT_LNORM, XTRACT_FLUX
+    XTRACT_F0, XTRACT_FAILSAFE_F0, XTRACT_WAVELET_F0, XTRACT_MCLEOD_F0,
+    XTRACT_MIDICENT
 };
 
-#define N_ELIGIBLE ((int)(sizeof(eligible) / sizeof(eligible[0])))
-#define MAX_N 2048   /* bound per-exec cost (f0/mcleod_f0 are O(N^2)) */
+#define N_ENUM ((int)(sizeof(enum_features) / sizeof(enum_features[0])))
+/* peak has no enum / dispatch slot, so it is one extra feature called directly. */
+#define N_FEATURES (N_ENUM + 1)
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    (void)argc;
+    (void)argv;
+    xtract_init_fft(FFT_N, XTRACT_SPECTRUM);
+    xtract_init_wavelet_f0_state();
+    return 0;
+}
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    int sel;
     int feature;
     int n;
+    int (*fn)(const double *, const int, const void *, double *);
     double argv[XTRACT_MAXARGS];
     double *in;
     double *result;
     size_t argv_bytes;
+    size_t avail;
 
     if (size < 1)
         return 0;
 
-    feature = eligible[data[0] % N_ELIGIBLE];
+    sel = data[0] % N_FEATURES;
     data++;
     size--;
 
-    /* First bytes (up to XTRACT_MAXARGS doubles) become argv; the rest is the
-     * input vector. Both are copied into aligned buffers so a misaligned read
-     * can't be mistaken for a library bug. */
     memset(argv, 0, sizeof(argv));
     argv_bytes = size < sizeof(argv) ? size : sizeof(argv);
     memcpy(argv, data, argv_bytes);
     data += argv_bytes;
     size -= argv_bytes;
 
-    n = (int)(size / sizeof(double));
-    if (n < 1)
-        return 0;
-    if (n > MAX_N)
-        n = MAX_N;
+    if (sel < N_ENUM)
+    {
+        feature = enum_features[sel];
+        fn = xtract[feature];
+    }
+    else
+    {
+        feature = -1;
+        fn = xtract_peak;
+    }
 
-    in = (double *)malloc((size_t)n * sizeof(double));
+    /* The two state-dependent features run at the size they were initialised
+     * for, reading a full window padded with zeros when the fuzzer gave less. */
+    if (fn == xtract[XTRACT_FAILSAFE_F0])
+        n = FFT_N;
+    else if (fn == xtract[XTRACT_WAVELET_F0])
+        n = WAVELET_N;
+    else
+    {
+        n = (int)(size / sizeof(double));
+        if (n < 1)
+            return 0;
+        if (n > MAX_N)
+            n = MAX_N;
+    }
+
+    in = (double *)calloc((size_t)n, sizeof(double));
     /* Over-allocate the result: covered features write a single value, but the
      * margin keeps a harness mis-sizing from masquerading as an overflow. */
     result = (double *)calloc((size_t)n + 64, sizeof(double));
@@ -83,9 +121,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         free(result);
         return 0;
     }
-    memcpy(in, data, (size_t)n * sizeof(double));
+    avail = size / sizeof(double);
+    memcpy(in, data, (avail < (size_t)n ? avail : (size_t)n) * sizeof(double));
 
-    (void)xtract[feature](in, n, argv, result);
+    (void)fn(in, n, argv, result);
 
     free(in);
     free(result);

--- a/fuzz/fuzz_vector.c
+++ b/fuzz/fuzz_vector.c
@@ -1,0 +1,217 @@
+/*
+ * libFuzzer harness for the vector feature functions (xtract_vector.h).
+ *
+ * These write an array (not a scalar) into result and, unlike the scalar/delta
+ * features, each needs specific setup: an FFT plan, a mel/gammatone filterbank,
+ * or bark band limits, plus an argv whose shape differs per feature. The
+ * filterbanks, bark limits, and FFT plans are built once at a fixed
+ * power-of-two N in LLVMFuzzerInitialize; every call then runs at that N.
+ * Features are called by name (two of them, mmbses and
+ * spectral_subband_centroids, have no xtract[] dispatch slot).
+ *
+ * What is fuzzed: the input vector (always) and the plain scalar argv fields
+ * (spectrum type, peak/harmonic thresholds, f0). What is held valid: the
+ * filterbank/bark pointers (we fuzz each feature's maths on adversarial input,
+ * not the init routines), and the argv fields that select the result size or a
+ * dispatch target (subbands' function and band count, lpcc's order) -- feeding
+ * those garbage would overflow the harness's own buffer or call out of the
+ * xtract[] table, which is out of contract rather than a library bug.
+ *
+ * The result buffer is sized to the largest need across all features
+ * (peak_spectrum's 2N) plus a margin. Run under AddressSanitizer + UBSan.
+ *
+ * Build/run: make fuzz   (see fuzz/Makefile)
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "xtract/libxtract.h"
+#include "xtract/xtract_vector.h"
+
+enum { VEC_N = 512, N_FILTERS = 13, RESULT_CAP = 2 * VEC_N + 64 };
+
+enum {
+    FZ_SPECTRUM, FZ_AUTOCORRELATION_FFT, FZ_MFCC, FZ_MEL_SPECTROGRAM,
+    FZ_GFCC, FZ_GAMMATONE_SPECTROGRAM, FZ_MMBSES,
+    FZ_SPECTRAL_SUBBAND_CENTROIDS, FZ_DCT, FZ_AUTOCORRELATION, FZ_AMDF,
+    FZ_ASDF, FZ_BARK_COEFFICIENTS, FZ_PEAK_SPECTRUM, FZ_HARMONIC_SPECTRUM,
+    FZ_LPC, FZ_LPCC, FZ_SUBBANDS, FZ_N_FEATURES
+};
+
+static const double SR = 44100.0;
+static const double NYQUIST = 22050.0;
+
+static xtract_mel_filter mel;
+static xtract_mel_filter gammatone;
+static int bark_limits[XTRACT_BARK_BANDS];
+
+static double **alloc_filterbank(void)
+{
+    double **f = (double **)malloc(N_FILTERS * sizeof(double *));
+    int i;
+    if (f == NULL)
+        return NULL;
+    for (i = 0; i < N_FILTERS; i++)
+        f[i] = (double *)calloc(VEC_N, sizeof(double));
+    return f;
+}
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    (void)argc;
+    (void)argv;
+
+    mel.n_filters = N_FILTERS;
+    mel.filters = alloc_filterbank();
+    xtract_init_mfcc(VEC_N, NYQUIST, XTRACT_EQUAL_GAIN, 20.0, 8000.0,
+                     N_FILTERS, mel.filters);
+
+    gammatone.n_filters = N_FILTERS;
+    gammatone.filters = alloc_filterbank();
+    xtract_init_gfcc(VEC_N, NYQUIST, 20.0, 8000.0, N_FILTERS,
+                     gammatone.filters);
+
+    xtract_init_bark(VEC_N, SR, bark_limits);
+
+    xtract_init_fft(VEC_N, XTRACT_SPECTRUM);
+    xtract_init_fft(VEC_N, XTRACT_AUTOCORRELATION_FFT);
+    xtract_init_fft(VEC_N, XTRACT_DCT);
+    return 0;
+}
+
+/* Map a fuzzer double to an int in [lo, hi], treating NaN/out-of-range as lo. */
+static int clamp_int(double v, int lo, int hi)
+{
+    if (!(v >= (double)lo))
+        return lo;
+    if (v > (double)hi)
+        return hi;
+    return (int)v;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    int feature;
+    double fz[8];
+    double *in;
+    double *result;
+    size_t fz_bytes;
+    size_t avail;
+
+    if (size < 1)
+        return 0;
+
+    feature = data[0] % FZ_N_FEATURES;
+    data++;
+    size--;
+
+    /* Carve a small prefix for the scalar argv fields; the rest is the input. */
+    memset(fz, 0, sizeof(fz));
+    fz_bytes = size < sizeof(fz) ? size : sizeof(fz);
+    memcpy(fz, data, fz_bytes);
+    data += fz_bytes;
+    size -= fz_bytes;
+
+    in = (double *)calloc(VEC_N, sizeof(double));
+    result = (double *)calloc(RESULT_CAP, sizeof(double));
+    if (in == NULL || result == NULL)
+    {
+        free(in);
+        free(result);
+        return 0;
+    }
+    avail = size / sizeof(double);
+    if (avail > VEC_N)
+        avail = VEC_N;
+    memcpy(in, data, avail * sizeof(double));
+
+    switch (feature)
+    {
+    case FZ_SPECTRUM:
+    {
+        double a[4] = { fz[0], fz[1], fz[2], fz[3] };
+        xtract_spectrum(in, VEC_N, a, result);
+        break;
+    }
+    case FZ_PEAK_SPECTRUM:
+    {
+        double a[2] = { fz[0], fz[1] };
+        xtract_peak_spectrum(in, VEC_N, a, result);
+        break;
+    }
+    case FZ_HARMONIC_SPECTRUM:
+    {
+        double a[2] = { fz[0], fz[1] };
+        xtract_harmonic_spectrum(in, VEC_N, a, result);
+        break;
+    }
+    case FZ_MFCC:
+        xtract_mfcc(in, VEC_N, &mel, result);
+        break;
+    case FZ_MEL_SPECTROGRAM:
+        xtract_mel_spectrogram(in, VEC_N, &mel, result);
+        break;
+    case FZ_MMBSES:
+        xtract_mmbses(in, VEC_N, &mel, result);
+        break;
+    case FZ_SPECTRAL_SUBBAND_CENTROIDS:
+        xtract_spectral_subband_centroids(in, VEC_N, &mel, result);
+        break;
+    case FZ_GFCC:
+        xtract_gfcc(in, VEC_N, &gammatone, result);
+        break;
+    case FZ_GAMMATONE_SPECTROGRAM:
+        xtract_gammatone_spectrogram(in, VEC_N, &gammatone, result);
+        break;
+    case FZ_BARK_COEFFICIENTS:
+        xtract_bark_coefficients(in, VEC_N, bark_limits, result);
+        break;
+    case FZ_SUBBANDS:
+    {
+        /* argv = {scalar function, band count, frequency scale, start bin}.
+         * Constrain to a valid dispatch target and a band count the result
+         * buffer can hold; only the start bin is freely fuzzed. */
+        int a[4];
+        a[0] = (fz[0] < 0.0) ? XTRACT_SUM : XTRACT_MEAN;
+        a[1] = clamp_int(fz[1], 1, VEC_N);
+        a[2] = (fz[2] < 0.0) ? XTRACT_OCTAVE_SUBBANDS : XTRACT_LINEAR_SUBBANDS;
+        a[3] = clamp_int(fz[3], 0, VEC_N - 1);
+        xtract_subbands(in, VEC_N, a, result);
+        break;
+    }
+    case FZ_LPCC:
+    {
+        /* argv = order Q, which is also the result length. */
+        int order = clamp_int(fz[0], 1, VEC_N);
+        xtract_lpcc(in, VEC_N, &order, result);
+        break;
+    }
+    case FZ_AUTOCORRELATION_FFT:
+        xtract_autocorrelation_fft(in, VEC_N, NULL, result);
+        break;
+    case FZ_DCT:
+        xtract_dct(in, VEC_N, NULL, result);
+        break;
+    case FZ_AUTOCORRELATION:
+        xtract_autocorrelation(in, VEC_N, NULL, result);
+        break;
+    case FZ_AMDF:
+        xtract_amdf(in, VEC_N, NULL, result);
+        break;
+    case FZ_ASDF:
+        xtract_asdf(in, VEC_N, NULL, result);
+        break;
+    case FZ_LPC:
+        xtract_lpc(in, VEC_N, NULL, result);
+        break;
+    default:
+        break;
+    }
+
+    free(in);
+    free(result);
+    return 0;
+}

--- a/fuzz/fuzz_vector.c
+++ b/fuzz/fuzz_vector.c
@@ -32,6 +32,9 @@
 #include "xtract/xtract_vector.h"
 
 enum { VEC_N = 512, N_FILTERS = 13, RESULT_CAP = 2 * VEC_N + 64 };
+/* mmbses reads data as N interleaved complex pairs (data[n*2], data[n*2+1]),
+ * so it touches 2*N doubles; give every feature an input of that width. */
+enum { IN_CAP = 2 * VEC_N };
 
 enum {
     FZ_SPECTRUM, FZ_AUTOCORRELATION_FFT, FZ_MFCC, FZ_MEL_SPECTROGRAM,
@@ -115,7 +118,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     data += fz_bytes;
     size -= fz_bytes;
 
-    in = (double *)calloc(VEC_N, sizeof(double));
+    in = (double *)calloc(IN_CAP, sizeof(double));
     result = (double *)calloc(RESULT_CAP, sizeof(double));
     if (in == NULL || result == NULL)
     {
@@ -124,8 +127,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return 0;
     }
     avail = size / sizeof(double);
-    if (avail > VEC_N)
-        avail = VEC_N;
+    if (avail > IN_CAP)
+        avail = IN_CAP;
     memcpy(in, data, avail * sizeof(double));
 
     switch (feature)

--- a/src/Make.config
+++ b/src/Make.config
@@ -8,7 +8,9 @@ ifeq ($(PLATFORM), Darwin)
     # clang-only: warn when a variable may be read uninitialised on some paths
     FLAGS += -Wconditional-uninitialized
 else
-    FLAGS += -DUSE_OOURA
+    # -fopenmp-simd enables the #pragma omp simd reduction hints in the scalar
+    # paths (the macOS paths use vDSP instead). SIMD subset only, no runtime.
+    FLAGS += -DUSE_OOURA -fopenmp-simd
 endif
 
 # Unused for the static archive, but a shared library must link the

--- a/src/delta.c
+++ b/src/delta.c
@@ -26,6 +26,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include "xtract/libxtract.h"
+#include "xtract_macros_private.h"
 
 /* Direct multiplication for the common small integer orders, avoiding pow()'s
  * exp(order * log(base)) dispatch in the inner loop. base is non-negative. */
@@ -80,8 +81,8 @@ int xtract_lnorm(const double *data, const int N, const void *argv , double *res
     double order;
 
     order = *(double *)argv;
-    type = *((double *)argv+1);
-    normalise = (int)*((double *)argv+2);
+    type = xtract_argv_int(*((double *)argv+1));
+    normalise = xtract_argv_int(*((double *)argv+2));
 
     order = order > 0 ? order : 2.0;
 

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -51,14 +51,14 @@ int xtract_mean(const double *data, const int N, const void *argv, double *resul
 #ifdef __APPLE__
     vDSP_meanvD(data, 1, result, N);
 #else
-    int n = N;
+    int n;
+    double sum = 0.0;
 
-    *result = 0.0;
+    #pragma omp simd reduction(+:sum)
+    for(n = 0; n < N; n++)
+        sum += data[n];
 
-    while(n--)
-        *result += data[n];
-
-    *result /= N;
+    *result = sum / N;
 #endif
 
     return XTRACT_SUCCESS;
@@ -81,15 +81,15 @@ int xtract_variance(const double *data, const int N, const void *argv, double *r
     *result *= (double)N / (N - 1); /* Bessel correction */
     free(shifted);
 #else
-    int n = N;
+    int n;
     const double arg0 = *(double *)argv;
+    double sum = 0.0;
 
-    *result = 0.0;
+    #pragma omp simd reduction(+:sum)
+    for(n = 0; n < N; n++)
+        sum += XTRACT_SQ(data[n] - arg0);
 
-    while(n--)
-        *result += XTRACT_SQ(data[n] - arg0);
-
-    *result /= (N - 1);
+    *result = sum / (N - 1);
 #endif
 
     return XTRACT_SUCCESS;
@@ -121,15 +121,15 @@ int xtract_average_deviation(const double *data, const int N, const void *argv, 
     vDSP_meanvD(temp, 1, result, N);
     free(temp);
 #else
-    int n = N;
+    int n;
     const double arg0 = *(double *)argv;
+    double sum = 0.0;
 
-    *result = 0.0;
+    #pragma omp simd reduction(+:sum)
+    for(n = 0; n < N; n++)
+        sum += fabs(data[n] - arg0);
 
-    while(n--)
-        *result += fabs(data[n] - arg0);
-
-    *result /= N;
+    *result = sum / N;
 #endif
 
     return XTRACT_SUCCESS;
@@ -195,22 +195,22 @@ int xtract_kurtosis(const double *data, const int N, const void *argv,  double *
 int xtract_spectral_centroid(const double *data, const int N, const void *argv,  double *result)
 {
 
-    int n = (N >> 1);
-
-    const double *freqs, *amps;
+    const int n = (N >> 1);
+    const double *amps = data;
+    const double *freqs = data + n;
     double FA = 0.0, A = 0.0;
-
-    amps = data;
-    freqs = data + n;
 
 #ifdef __APPLE__
     vDSP_dotprD(amps, 1, freqs, 1, &FA, n);
     vDSP_sveD(amps, 1, &A, n);
 #else
-    while(n--)
+    int m;
+
+    #pragma omp simd reduction(+:FA,A)
+    for(m = 0; m < n; m++)
     {
-        FA += freqs[n] * amps[n];
-        A += amps[n];
+        FA += freqs[m] * amps[m];
+        A += amps[m];
     }
 #endif
 
@@ -755,13 +755,14 @@ int xtract_rms_amplitude(const double *data, const int N, const void *argv, doub
 #ifdef __APPLE__
     vDSP_rmsqvD(data, 1, result, N);
 #else
-    int n = N;
+    int n;
+    double sum = 0.0;
 
-    *result = 0.0;
+    #pragma omp simd reduction(+:sum)
+    for(n = 0; n < N; n++)
+        sum += XTRACT_SQ(data[n]);
 
-    while(n--) *result += XTRACT_SQ(data[n]);
-
-    *result = sqrt(*result / (double)N);
+    *result = sqrt(sum / (double)N);
 #endif
 
     return XTRACT_SUCCESS;
@@ -990,12 +991,14 @@ int xtract_sum(const double *data, const int N, const void *argv, double *result
 #ifdef __APPLE__
     vDSP_sveD(data, 1, result, N);
 #else
-    int n = N;
+    int n;
+    double sum = 0.0;
 
-    *result = 0.0;
+    #pragma omp simd reduction(+:sum)
+    for(n = 0; n < N; n++)
+        sum += data[n];
 
-    while(n--)
-        *result += *data++;
+    *result = sum;
 #endif
 
     return XTRACT_SUCCESS;

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -250,15 +250,17 @@ int xtract_spectral_variance(const double *data, const int N, const void *argv, 
     vDSP_sveD(amps, 1, &A, m);                /* sum(amps) */
     free(d);
 #else
-    int mm = m;
+    int mm;
+    double sum = 0.0;
 
-    *result = 0.0;
-
-    while(mm--)
+    #pragma omp simd reduction(+:A,sum)
+    for(mm = 0; mm < m; mm++)
     {
         A += amps[mm];
-        *result += XTRACT_SQ(freqs[mm] - arg0) * amps[mm];
+        sum += XTRACT_SQ(freqs[mm] - arg0) * amps[mm];
     }
+
+    *result = sum;
 #endif
 
     if (A == 0.0)
@@ -292,7 +294,8 @@ int xtract_spectral_skewness(const double *data, const int N, const void *argv, 
     double neg_c = -arg0;
     double *d, *t;
 #else
-    int mm = m;
+    int mm;
+    double sum = 0.0;
 #endif
 
     *result = 0.0;
@@ -314,11 +317,14 @@ int xtract_spectral_skewness(const double *data, const int N, const void *argv, 
     vDSP_sveD(amps, 1, &sum_amps, m);
     free(d);
 #else
-    while(mm--)
+    #pragma omp simd reduction(+:sum,sum_amps)
+    for(mm = 0; mm < m; mm++)
     {
-        *result += XTRACT_POW3(freqs[mm] - arg0) * amps[mm];
+        sum += XTRACT_POW3(freqs[mm] - arg0) * amps[mm];
         sum_amps += amps[mm];
     }
+
+    *result = sum;
 #endif
 
     if(sum_amps == 0.0)
@@ -345,7 +351,8 @@ int xtract_spectral_kurtosis(const double *data, const int N, const void *argv, 
     double neg_c = -arg0;
     double *d;
 #else
-    int mm = m;
+    int mm;
+    double sum = 0.0;
 #endif
 
     if (arg1 == 0.0)
@@ -367,11 +374,14 @@ int xtract_spectral_kurtosis(const double *data, const int N, const void *argv, 
     vDSP_sveD(amps, 1, &sum_amps, m);
     free(d);
 #else
-    while(mm--)
+    #pragma omp simd reduction(+:sum,sum_amps)
+    for(mm = 0; mm < m; mm++)
     {
-        *result += XTRACT_POW4(freqs[mm] - arg0) * amps[mm];
+        sum += XTRACT_POW4(freqs[mm] - arg0) * amps[mm];
         sum_amps += amps[mm];
     }
+
+    *result = sum;
 #endif
 
     if(sum_amps == 0.0)

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -448,7 +448,7 @@ int xtract_tristimulus_1(const double *data, const int N, const void *argv, doub
         if((temp = data[i]))
         {
             den += temp;
-            h = (int)floor(freqs[i] / fund + 0.5);
+            h = xtract_argv_int(floor(freqs[i] / fund + 0.5));
             if(h == 1)
                 p1 += temp;
         }
@@ -482,7 +482,7 @@ int xtract_tristimulus_2(const double *data, const int N, const void *argv, doub
         if((temp = data[i]))
         {
             den += temp;
-            h = (int)floor(freqs[i] / fund + 0.5);
+            h = xtract_argv_int(floor(freqs[i] / fund + 0.5));
             switch ((int)h)
             {
                 case 2:
@@ -532,7 +532,7 @@ int xtract_tristimulus_3(const double *data, const int N, const void *argv, doub
         if((temp = data[i]))
         {
             den += temp;
-            h = (int)floor(freqs[i] / fund + 0.5);
+            h = xtract_argv_int(floor(freqs[i] / fund + 0.5));
             if(h >= 5)
                 num += temp;
         }
@@ -798,7 +798,7 @@ int xtract_spectral_inharmonicity(const double *data, const int N, const void *a
     {
         if(amps[n])
         {
-            h = (int)floor(freqs[n] / fund + 0.5);
+            h = xtract_argv_int(floor(freqs[n] / fund + 0.5));
             num += fabs(freqs[n] - h * fund) * XTRACT_SQ(amps[n]);
             den += XTRACT_SQ(amps[n]);
         }
@@ -842,7 +842,7 @@ int xtract_odd_even_ratio(const double *data, const int N, const void *argv, dou
     {
         if((temp = data[n]))
         {
-            h = (int)floor(freqs[n] / fund + 0.5);
+            h = xtract_argv_int(floor(freqs[n] / fund + 0.5));
 
             /* Harmonics are numbered from 1: a bin nearest to harmonic
              * zero is below the first harmonic and belongs to neither sum */

--- a/src/vector.c
+++ b/src/vector.c
@@ -63,9 +63,9 @@ int xtract_spectrum(const double *data, const int N, const void *argv, double *r
 #endif
 
     q = *(double *)argv;
-    vector = (int)*((double *)argv+1);
-    withDC = (int)*((double *)argv+2);
-    normalise = (int)*((double *)argv+3);
+    vector = xtract_argv_int(*((double *)argv+1));
+    withDC = xtract_argv_int(*((double *)argv+2));
+    normalise = xtract_argv_int(*((double *)argv+3));
 
     XTRACT_CHECK_q;
 #ifdef USE_OOURA

--- a/src/xtract_macros_private.h
+++ b/src/xtract_macros_private.h
@@ -57,4 +57,13 @@
 #define XTRACT_SPEC_BW_DEF 43.066 /* SR_DEFAULT / FFT_BANDS_DEF */
 #define XTRACT_ARRAY_ELEMENTS(_array) (sizeof(_array)/sizeof(_array[0]))
 
+/* Safe double->int conversion: out-of-range and NaN inputs yield 0 rather than
+ * the undefined behaviour of a direct cast (the >= / < comparisons are both
+ * false for NaN). Used for argv fields and computed harmonic numbers that an
+ * adversarial input could push outside int's range. */
+static inline int xtract_argv_int(double v)
+{
+    return (v >= -2147483648.0 && v < 2147483648.0) ? (int)v : 0;
+}
+
 #endif

--- a/tests/xttest_delta.c
+++ b/tests/xttest_delta.c
@@ -91,3 +91,20 @@ UTEST(delta, decay_time_not_implemented)
     double result = -1.0;
     ASSERT_EQ(xtract_decay_time(data, 4, NULL, &result), XTRACT_FEATURE_NOT_IMPLEMENTED);
 }
+
+UTEST(delta, lnorm_out_of_range_argv)
+{
+    /* type/normalise are decoded from doubles; out-of-range or NaN values must
+     * not invoke undefined double->int conversion (regression for a fuzzer
+     * find). They fall back to the default filter / no normalisation, so the
+     * L2 norm of {1,-2,3,-4} = sqrt(30) is computed regardless. */
+    double data[] = {1.0, -2.0, 3.0, -4.0};
+    double argv_nan[3]  = {2.0, NAN, NAN};
+    double argv_huge[3] = {2.0, 1e308, -1e308};
+    double result = -1.0;
+
+    ASSERT_EQ(xtract_lnorm(data, 4, argv_nan, &result), XTRACT_SUCCESS);
+    CHECK_REL(result, sqrt(30.0), 1e-10);
+    ASSERT_EQ(xtract_lnorm(data, 4, argv_huge, &result), XTRACT_SUCCESS);
+    CHECK_REL(result, sqrt(30.0), 1e-10);
+}

--- a/tests/xttest_scalar.c
+++ b/tests/xttest_scalar.c
@@ -2089,3 +2089,15 @@ UTEST(scalar, peak_below_threshold)
     int rv = xtract_peak(data, 4, &threshold, &result);
     ASSERT_EQ(rv, XTRACT_NO_RESULT);
 }
+
+UTEST(scalar, harmonic_number_no_ub_on_zero_fundamental)
+{
+    /* The harmonic number round(freq/fund) must not invoke undefined
+     * double->int conversion when fund is 0 (the ratio is infinite); the bin
+     * maps to no finite harmonic, so no fundamental energy is found.
+     * Regression for a fuzzer-found UB in the tristimulus/harmonic features. */
+    double data[] = {1.0, 2.0, 100.0, 200.0}; /* amplitudes, frequencies */
+    double fund0 = 0.0;
+    double result = -1.0;
+    ASSERT_EQ(xtract_tristimulus_1(data, 4, &fund0, &result), XTRACT_NO_RESULT);
+}


### PR DESCRIPTION
## Summary

Fuzzing for the feature functions (Milestone 1.1, item 4), bundled with the UB fix it found. Harnesses are split to mirror the library's feature headers.

| Harness | Header | Coverage |
|---|---|---|
| `fuzz_scalar.c` | `xtract_scalar.h` | all 43 dispatch-table features + `peak` (direct call, no enum); `failsafe_f0` at an FFT-initialised N, `wavelet_f0` at its state-initialised N |
| `fuzz_delta.c` | `xtract_delta.h` | flux, lnorm, attack_time, decay_time, difference_vector |
| `fuzz_vector.c` | `xtract_vector.h` | all 18 array-output features; FFT plans, mel/gammatone filterbanks and bark limits built once at a fixed N |

Each harness's mutated bytes become a feature selector, an `argv` buffer, and the input vector, so NaN, ±Inf, denormals, `N=1`, all-zero, etc. are exercised. In `fuzz_vector.c` the input and plain scalar `argv` fields are fuzzed while `argv` fields that select the result size or an internal dispatch target (subbands' function/band-count, lpcc's order) are held to valid ranges — feeding those garbage would overflow the harness's own buffer or dispatch out of range, which is out of contract rather than a library bug.

- **`make fuzz`** builds the library + all three harnesses with `-fsanitize=fuzzer` + ASan/UBSan, runs each for `FUZZ_TIME`s, then restores the normal build. Apple clang lacks the libFuzzer runtime (use brew LLVM); ASan's runtime deadlocks at init on some macOS toolchains, so `FUZZ_SAN=undefined` is available there. CI runs the full set on Linux.
- **CI**: a gating `fuzz` job on `ubuntu-latest` runs `make fuzz FUZZ_TIME=60` and uploads any crash reproducer on failure.

## The UB fix

Fuzzing surfaced undefined behaviour from direct `double -> int` casts. Per C11 §6.3.1.4, converting a NaN, infinite, or out-of-range floating value to an integer type is undefined — and a *finite* value beyond `int`'s range (e.g. `1e308`) is undefined too, so neither a wider integer nor switching to `float` would fix it.

Affected sites, now routed through a new `xtract_argv_int` guard (maps out-of-range/NaN → 0):
- argv-decoded fields: `xtract_lnorm` (type, normalise), `xtract_spectrum` (vector, withDC, normalise)
- computed harmonic numbers: `xtract_tristimulus_1/2/3`, `xtract_spectral_inharmonicity`, `xtract_odd_even_ratio`

## Tests

- `delta/lnorm_out_of_range_argv`: NaN and huge argv fields fall back to defaults and still compute the L2 norm.
- `scalar/harmonic_number_no_ub_on_zero_fundamental`: a zero fundamental no longer triggers the UB path.

Local `make && make check` is green (242 tests); a UBSan run of all three harnesses after the fix is clean.