### PR TITLE
chore: add .clang-format capturing the house style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,37 @@
+# LibXtract house style (see README "Code standard" and CONTRIBUTING).
+# Allman braces, 4-space indent, pointer binds to the variable, no space
+# between a keyword and its parenthesis. ColumnLimit is 0: clang-format
+# normalises indentation/braces/spacing but never reflows long lines.
+---
+Language: Cpp
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 0
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: true
+  AfterControlStatement: Always
+  AfterEnum: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeElse: true
+  BeforeWhile: false
+  AfterCaseLabel: false
+  SplitEmptyFunction: true
+  IndentBraces: false
+PointerAlignment: Right
+SpaceBeforeParens: Never
+SpaceAfterCStyleCast: false
+SpacesInParentheses: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+IndentCaseLabels: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+SortIncludes: false
+AlignTrailingComments: true

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ and by `make analyze`, which runs the clang static analyzer over the
 first-party sources and fails on any finding; CI runs it on Linux and
 macOS.
 
+Formatting follows Allman brace style (the opening brace on its own line
+for functions and control flow, but same-line braces for `struct`, `enum`
+and `extern "C"`), four-space indentation with no tabs, the pointer
+asterisk bound to the variable (`const double *data`), and no space between
+a keyword and its parenthesis (`if(x)`, `for(i = 0; ...)`). These rules are
+captured as executable configuration in `.clang-format`; run `clang-format
+--dry-run <file>` to check a file against them, or `clang-format -i <file>`
+to apply them.
+
 ## API stability
 
 LibXtract follows [Semantic Versioning](https://semver.org). The public API


### PR DESCRIPTION
## Summary

First of three PRs for Milestone 1.1 item 5 (init-style reformat + clang-format). This one adds **only** the formatting spec — it is **non-enforcing**: nothing is reformatted and no CI gate is added yet.

`.clang-format` encodes the documented house style:
- Allman braces for **functions and control flow**, but **same-line** braces for `struct`, `enum`, and `extern "C"` (custom `BraceWrapping`)
- four-space indent, no tabs
- pointer asterisk binds to the variable (`const double *data`)
- no space between a keyword and its parenthesis (`if(x)`, `for(i = 0; ...)`)
- `ColumnLimit: 0` — normalises indentation/braces/spacing but **never reflows long lines** (keeps churn proportionate and matches the existing code, which doesn't wrap)

README's "Code standard" section now points to it (`clang-format --dry-run <file>` to check, `-i` to apply).

## Why non-enforcing now

The whole-tree reformat rewrites `git blame` and the enforcing CI check would gate every push, so per the roadmap those land together in a later PR (after the init-style sweep), so the disruptive churn happens once. This PR lets the style be reviewed as executable config first.

## Validation

The config was checked against representative files to confirm it captures current house style rather than fighting it: recently-written files barely move (e.g. the delta tests change 2 lines), while the deltas it does produce in legacy files are all legitimate drift — pointer binding (`double**`→`double **`), operator spacing (`argv+1`→`argv + 1`), tabs→spaces in the OOURA blocks, and consistent `case` indentation. Valid under clang-format 20 and 22 (no config errors). `make` + `make check` green (242 tests); no source files changed.

Part of #milestone-1.1 item 5 (PRs B = init-style sweep, C = whole-tree reformat + enforcing CI to follow).