### PR TITLE
chore: initialise-at-declaration for the remaining adjacent locals

### DIFF
--- a/src/delta.c
+++ b/src/delta.c
@@ -78,9 +78,8 @@ int xtract_lnorm(const double *data, const int N, const void *argv , double *res
         normalise,
         k = 0;
 
-    double order;
+    double order = *(double *)argv;
 
-    order = *(double *)argv;
     type = xtract_argv_int(*((double *)argv+1));
     normalise = xtract_argv_int(*((double *)argv+2));
 
@@ -156,9 +155,7 @@ int xtract_difference_vector(const double *data, const int N, const void *argv, 
     const double *frame1,
           *frame2;
 
-    int n;
-
-    n = N >> 1;
+    int n = N >> 1;
 
     frame1 = data;
     frame2 = data + n;

--- a/src/init.c
+++ b/src/init.c
@@ -477,9 +477,7 @@ int xtract_init_wavelet_f0_state(void)
 
 double *xtract_init_window(const int N, const int type)
 {
-    double *window;
-
-    window = (double*)malloc(N * sizeof(double));
+    double *window = (double *)malloc(N * sizeof(double));
     if(window == NULL)
         return NULL;
 

--- a/src/scalar.c
+++ b/src/scalar.c
@@ -692,9 +692,7 @@ int xtract_flatness(const double *data, const int N, const void *argv, double *r
 int xtract_flatness_db(const double *data, const int N, const void *argv, double *result)
 {
 
-    double flatness;
-
-    flatness = *(double *)argv;
+    double flatness = *(double *)argv;
 
     if (flatness <= 0)
         flatness = XTRACT_LOG_LIMIT;
@@ -708,9 +706,7 @@ int xtract_flatness_db(const double *data, const int N, const void *argv, double
 int xtract_tonality(const double *data, const int N, const void *argv, double *result)
 {
 
-    double sfmdb;
-
-    sfmdb = *(double *)argv;
+    double sfmdb = *(double *)argv;
 
     *result = XTRACT_MIN(sfmdb / -60.0, 1);
 
@@ -1174,9 +1170,7 @@ int xtract_failsafe_f0(const double *data, const int N, const void *argv, double
 {
 
     double *spectrum, argf[4], *peaks, sr;
-    int rv;
-
-    rv = xtract_f0(data, N, argv, result);
+    int rv = xtract_f0(data, N, argv, result);
 
     if(rv == XTRACT_NO_RESULT)
     {

--- a/src/vector.c
+++ b/src/vector.c
@@ -483,9 +483,7 @@ static int filterbank_spectrogram(const double *data, const int N, const xtract_
 static int cepstral_coefficients(const double *data, const int N, const xtract_mel_filter *f, double *result)
 {
 
-    double *temp;
-
-    temp = (double *)calloc(f->n_filters, sizeof(double));
+    double *temp = (double *)calloc(f->n_filters, sizeof(double));
     if(temp == NULL)
         return XTRACT_MALLOC_FAILED;
 


### PR DESCRIPTION
## Summary

Milestone 1.1 item 5, part B. Migrates the locals that were declared and then assigned a known value on the next line to **initialise-at-declaration**, per the README "Code standard". Behaviour-neutral.

Seven sites (all "declaration, blank, assignment" with no intervening dependency):
- `xtract_lnorm` — `order`
- `xtract_difference_vector` — `n`
- `xtract_init_window` — `window` (also fixes `(double*)` → `(double *)`)
- `xtract_flatness_db` — `flatness`
- `xtract_tonality` — `sfmdb`
- `xtract_failsafe_f0` — `rv`
- `cepstral_coefficients` — `temp`

Scope note: this covers the clear adjacent cases. It deliberately does **not** split combined multi-variable declarations or reorder non-adjacent assignments — those are higher-churn judgment calls with little readability gain, and the whole-tree `clang-format` pass (part C) handles pure formatting separately.

## Verification

`make` + `make check` green (242 tests). Edited lines are written in house style, so the upcoming `clang-format` reformat (part C) won't re-touch them.

Follows #175 (the `.clang-format` spec). Part C (whole-tree reformat + enforcing CI) will stack on this.