### PR TITLE
fix: round Bark band limits in xtract_init_bark

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -251,8 +251,7 @@ int xtract_init_bark(int N, double sr, int *band_limits)
     int bands = XTRACT_BARK_BANDS;
 
     while (bands--)
-        band_limits[bands] = edges[bands] / sr * N;
-    /* truncation instead of rounding: see issue #153 */
+        band_limits[bands] = (int)floor(edges[bands] / sr * N + 0.5);
 
     return XTRACT_SUCCESS;
 }

--- a/tests/xttest_vector.c
+++ b/tests/xttest_vector.c
@@ -549,6 +549,32 @@ UTEST(vector, lpc_3rd_order_coefficients_should_be_correct)
     CHECK_REL(result[5], 0.0555555556, 1e-6);
 }
 
+/* ===== xtract_init_bark ===== */
+
+UTEST(vector, init_bark_band_limits_are_rounded)
+{
+    /* Band edge frequencies are converted to bin indices by rounding to the
+     * nearest bin (round-half-up), not truncation. These expected limits are
+     * pinned for two representative sr/N pairs so the conversion can't silently
+     * regress to truncation, which would shift energy between adjacent bands. */
+    static const int expected_1024_44100[XTRACT_BARK_BANDS] = {
+        0, 2, 5, 7, 9, 12, 15, 18, 21, 25, 29, 34, 40, 46, 54,
+        63, 73, 86, 102, 123, 149, 179, 221, 279, 360, 476};
+    static const int expected_2048_48000[XTRACT_BARK_BANDS] = {
+        0, 4, 9, 13, 17, 22, 27, 33, 39, 46, 54, 63, 73, 85, 99,
+        115, 134, 158, 188, 226, 273, 329, 405, 512, 661, 875};
+    int band_limits[XTRACT_BARK_BANDS];
+    int i;
+
+    xtract_init_bark(1024, 44100.0, band_limits);
+    for (i = 0; i < XTRACT_BARK_BANDS; i++)
+        ASSERT_EQ(band_limits[i], expected_1024_44100[i]);
+
+    xtract_init_bark(2048, 48000.0, band_limits);
+    for (i = 0; i < XTRACT_BARK_BANDS; i++)
+        ASSERT_EQ(band_limits[i], expected_2048_48000[i]);
+}
+
 /* ===== xtract_bark_coefficients ===== */
 
 UTEST(vector, bark_coefficients_basic_summation)


### PR DESCRIPTION
Closes #153.

`xtract_init_bark` truncated when converting band edge frequencies to bin indices (`band_limits[bands] = edges[bands] / sr * N;`), biasing every edge downward. This switches to round-half-up (`(int)floor(edges/sr*N + 0.5)`).

### Behaviour change
Band limits shift by one bin for some samplerate/blocksize combinations, which moves energy between adjacent Bark bands and changes `bark_coefficients` / `loudness` / `sharpness` output slightly. This is intentional and matches the corrected band edges.

### Test
Adds `vector.init_bark_band_limits_are_rounded`, pinning the expected band limits for two representative sr/N pairs (1024/44100, 2048/48000) so the conversion can't silently regress to truncation.

`make`, `make check` (243 tests) and `make analyze` all pass locally.