### PR TITLE
feat: document the recommended lpcc cepstrum order and fix its descriptor entry

### DIFF
--- a/include/xtract/xtract_macros.h
+++ b/include/xtract/xtract_macros.h
@@ -44,6 +44,11 @@ extern "C"
 #define XTRACT_UNKNOWN_MAX DBL_MAX      /* upper bound has not been determined */
 #define XTRACT_NO_DEFAULT 0             /* no default value defined */
 #define XTRACT_MAXARGS 4
+
+/* Default LPC cepstrum order Q for a given LPC order p. Rabiner & Juang
+ * recommend Q ~ (3/2)p with Q > p; this rounds (3/2)p to the nearest integer
+ * (and keeps Q > p for all p >= 1). */
+#define XTRACT_LPCC_CEPSTRUM_ORDER(p) ((3 * (p) + 1) / 2)
 #define XTRACT_MAX_NAME_LENGTH 64
 #define XTRACT_MAX_AUTHOR_LENGTH 128
 #define XTRACT_MAX_DESC_LENGTH 256

--- a/include/xtract/xtract_macros.h
+++ b/include/xtract/xtract_macros.h
@@ -45,9 +45,10 @@ extern "C"
 #define XTRACT_NO_DEFAULT 0             /* no default value defined */
 #define XTRACT_MAXARGS 4
 
-/* Default LPC cepstrum order Q for a given LPC order p. Rabiner & Juang
+/* Recommended LPC cepstrum order Q for a given LPC order p. Rabiner & Juang
  * recommend Q ~ (3/2)p with Q > p; this rounds (3/2)p to the nearest integer
- * (and keeps Q > p for all p >= 1). */
+ * (and keeps Q > p for all p >= 1). Pass the result as xtract_lpcc's argv[0]
+ * to request this many cepstral coefficients. */
 #define XTRACT_LPCC_CEPSTRUM_ORDER(p) ((3 * (p) + 1) / 2)
 #define XTRACT_MAX_NAME_LENGTH 64
 #define XTRACT_MAX_AUTHOR_LENGTH 128

--- a/include/xtract/xtract_vector.h
+++ b/include/xtract/xtract_vector.h
@@ -222,10 +222,10 @@ extern "C"
      *
      * \param *data: a pointer to the first element in an array of LPC coeffiecients e.g. a pointer to the second half of the array pointed to by *result from xtract_lpc()
      * \param N: the number of LPC coefficients to be considered
-     * \param *argv: a pointer to an int representing the order (Q) of the result vector. Must be greater than 0. According to Rabiner and Juang the recommended ratio is Q ~ (3/2)N where N is the number of LPC coefficients and Q > N.
+     * \param *argv: a pointer to an int representing the order (Q) of the result vector. Must be greater than 0. According to Rabiner and Juang the recommended ratio is Q ~ (3/2)p where p is the number of LPC coefficients and Q > p; XTRACT_LPCC_CEPSTRUM_ORDER(p) computes this value. If argv is NULL, Q defaults to p (the result is then no longer than the input).
      * \param *result: a pointer to an array containing the resultant LPCC.
      *
-     * An array of size Q, where Q is given by argv[0] must be allocated, and *result must point to its first element.
+     * An array of size Q must be allocated, and *result must point to its first element. With an explicit argv, Q is argv[0]; with argv == NULL, Q is the number of LPC coefficients.
      *
      */
     int xtract_lpcc(const double *data, const int N, const void *argv, double *result);

--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -100,11 +100,19 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
         case XTRACT_GFCC:
         case XTRACT_GAMMATONE_SPECTROGRAM:
         case XTRACT_LPC:
-        case XTRACT_LPCC:
             *argv_min = XTRACT_UNBOUNDED_MIN;
             *argv_max = XTRACT_UNBOUNDED_MAX;
             *argv_def = XTRACT_NO_DEFAULT;
             *argv_unit = XTRACT_DBFS;
+            break;
+        case XTRACT_LPCC:
+            /* argv[0] is the cepstrum length (Q). When omitted, xtract_lpcc
+             * derives the default at runtime from the LPC order p via
+             * XTRACT_LPCC_CEPSTRUM_ORDER, so no static default applies here. */
+            *argv_min = 1;
+            *argv_max = XTRACT_UNBOUNDED_MAX;
+            *argv_def = XTRACT_NO_DEFAULT;
+            *argv_unit = (xtract_unit_t)XTRACT_NONE;
             break;
         case XTRACT_SPECTRAL_INHARMONICITY:
             *argv_min = 0.0;

--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -106,9 +106,9 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
             *argv_unit = XTRACT_DBFS;
             break;
         case XTRACT_LPCC:
-            /* argv[0] is the cepstrum length (Q). When omitted, xtract_lpcc
-             * derives the default at runtime from the LPC order p via
-             * XTRACT_LPCC_CEPSTRUM_ORDER, so no static default applies here. */
+            /* argv[0] is the cepstrum length (Q); when omitted xtract_lpcc
+             * defaults it to the LPC order p, so no static default applies.
+             * XTRACT_LPCC_CEPSTRUM_ORDER(p) gives the recommended Q. */
             *argv_min = 1;
             *argv_max = XTRACT_UNBOUNDED_MAX;
             *argv_def = XTRACT_NO_DEFAULT;

--- a/src/vector.c
+++ b/src/vector.c
@@ -912,11 +912,11 @@ int xtract_lpcc(const double *data, const int N, const void *argv, double *resul
 
     int n, k;
     double sum;
-    int order = N - 1; /* cepstrum order: see issue #152 */
+    int order = N - 1; /* LPC order p (data[0] is the gain term) */
     int cep_length;
 
     if (argv == NULL)
-        cep_length = N - 1; /* default should come from the descriptor: see issue #152 */
+        cep_length = XTRACT_LPCC_CEPSTRUM_ORDER(order); /* Rabiner Q ~ (3/2)p */
     else
     {
         cep_length = *(int *)argv;

--- a/src/vector.c
+++ b/src/vector.c
@@ -916,7 +916,7 @@ int xtract_lpcc(const double *data, const int N, const void *argv, double *resul
     int cep_length;
 
     if (argv == NULL)
-        cep_length = XTRACT_LPCC_CEPSTRUM_ORDER(order); /* Rabiner Q ~ (3/2)p */
+        cep_length = order; /* default keeps the output no longer than the input */
     else
     {
         cep_length = *(int *)argv;

--- a/tests/xttest_vector.c
+++ b/tests/xttest_vector.c
@@ -235,6 +235,23 @@ UTEST(vector, lpcc_computes_cepstral_recursion_for_int_argv)
     CHECK_REL(result[1], 0.375, EPSILON);
 }
 
+UTEST(vector, lpcc_null_argv_defaults_to_rabiner_cepstrum_order)
+{
+    /* With argv == NULL the cepstrum length defaults to Rabiner's
+     * Q = round((3/2)p). Here p = N - 1 = 2, so Q = 3, and the recursion
+     * extends one coefficient past the LPC order:
+     * c[1] = a[1] = 0.5
+     * c[2] = a[2] + (1 * c[1] * a[1]) / 2 = 0.375
+     * c[3] = (2 * c[2] * a[1]) / 3 = 0.125 */
+    double lpc[3] = {0.0, 0.5, 0.25};
+    double result[3] = {0};
+
+    ASSERT_EQ(xtract_lpcc(lpc, 3, NULL, result), XTRACT_SUCCESS);
+    CHECK_REL(result[0], 0.5, EPSILON);
+    CHECK_REL(result[1], 0.375, EPSILON);
+    CHECK_REL(result[2], 0.125, EPSILON);
+}
+
 /* ===== xtract_harmonic_spectrum ===== */
 
 UTEST(vector, harmonic_spectrum_zero_fundamental_yields_no_result_and_zeroed_output)

--- a/tests/xttest_vector.c
+++ b/tests/xttest_vector.c
@@ -235,21 +235,29 @@ UTEST(vector, lpcc_computes_cepstral_recursion_for_int_argv)
     CHECK_REL(result[1], 0.375, EPSILON);
 }
 
-UTEST(vector, lpcc_null_argv_defaults_to_rabiner_cepstrum_order)
+UTEST(vector, lpcc_null_argv_defaults_to_lpc_order)
 {
-    /* With argv == NULL the cepstrum length defaults to Rabiner's
-     * Q = round((3/2)p). Here p = N - 1 = 2, so Q = 3, and the recursion
-     * extends one coefficient past the LPC order:
+    /* With argv == NULL the cepstrum length defaults to the LPC order p, so
+     * the output is no longer than the input. Here p = N - 1 = 2:
      * c[1] = a[1] = 0.5
      * c[2] = a[2] + (1 * c[1] * a[1]) / 2 = 0.375
-     * c[3] = (2 * c[2] * a[1]) / 3 = 0.125 */
+     * The recursion never reaches c[3], so result[2] is left untouched. */
     double lpc[3] = {0.0, 0.5, 0.25};
-    double result[3] = {0};
+    double result[3] = {-1.0, -1.0, -1.0};
 
     ASSERT_EQ(xtract_lpcc(lpc, 3, NULL, result), XTRACT_SUCCESS);
     CHECK_REL(result[0], 0.5, EPSILON);
     CHECK_REL(result[1], 0.375, EPSILON);
-    CHECK_REL(result[2], 0.125, EPSILON);
+    ASSERT_EQ(result[2], -1.0);
+}
+
+UTEST(vector, lpcc_cepstrum_order_macro_rounds_three_halves_p)
+{
+    /* XTRACT_LPCC_CEPSTRUM_ORDER rounds (3/2)p and keeps Q > p. */
+    ASSERT_EQ(XTRACT_LPCC_CEPSTRUM_ORDER(1), 2);
+    ASSERT_EQ(XTRACT_LPCC_CEPSTRUM_ORDER(2), 3);
+    ASSERT_EQ(XTRACT_LPCC_CEPSTRUM_ORDER(4), 6);
+    ASSERT_EQ(XTRACT_LPCC_CEPSTRUM_ORDER(10), 15);
 }
 
 /* ===== xtract_harmonic_spectrum ===== */


### PR DESCRIPTION
Addresses #152.

`xtract_lpcc` carried two `FIX` notes: the `argv == NULL` default should come from a single source of truth, and the cepstrum order should follow Rabiner & Juang's `Q ~ (3/2)p`.

### What this does
- **Recommended-Q macro (single source of truth):** adds the public `XTRACT_LPCC_CEPSTRUM_ORDER(p) = round((3/2)p)` (keeps `Q > p` for all `p >= 1`), so callers can compute the literature-recommended cepstrum order and pass it as `argv[0]`.
- **Descriptor correction:** the LPCC argv entry was mis-grouped with the DBFS statistical scalars. Its single argv is the cepstrum length — an int, min 1, unit none.
- **Documentation:** the `xtract_lpcc` Doxygen now states the recommended `Q ~ (3/2)p`, points at the macro, and documents the result buffer-size contract for both the explicit-argv and `argv == NULL` paths.
- **Comment fix:** the misleading `Q = 3/2 p` note on the recursion's `order` variable is removed — that variable is the LPC order `p` and must stay `N-1` for the recursion's split point to be correct.

### Why the default is left at `p` (review feedback)
An earlier revision made the `argv == NULL` default `round((3/2)p)`, but that exceeds the input length for `p >= 3` and would overflow existing callers that sized `result[]` to the old default (`p`) or to the block size. Since the cepstrum length is normally a deliberate caller choice (and `(3/2)p` is a *recommendation*, not a forced value), the silent default stays at `p` — output no longer than input — with the recommended `Q` available explicitly via the macro. **No behaviour change.**

### Tests
- `lpcc_null_argv_defaults_to_lpc_order` pins the `argv == NULL` default at `p` and verifies nothing is written past it.
- `lpcc_cepstrum_order_macro_rounds_three_halves_p` pins the macro's rounding.

`make`, `make check` (244 tests), `make analyze` and `make format-check` pass locally.