### PR TITLE
feat: audit descriptor result ranges/units and add explicit unit enum members

### DIFF
--- a/include/xtract/libxtract.h
+++ b/include/xtract/libxtract.h
@@ -222,8 +222,11 @@ extern "C"
     /** \brief Enumeration of units*/
     typedef enum unit_
     {
-        /* values 0 and 1 are reserved by the removed members NONE and ANY,
-         * so the enumeration starts at 2 */
+        XTRACT_UNIT_UNKNOWN = -2, /* unit has not been determined */
+        XTRACT_UNIT_ANY = -1,     /* result inherits the input's unit */
+        XTRACT_UNIT_NONE = 0,     /* dimensionless */
+        /* value 1 is reserved; the dimensioned units start at 2 so their
+         * values stay stable across releases */
         XTRACT_HERTZ = 2,
         XTRACT_ANY_AMPLITUDE_HERTZ,
         XTRACT_DBFS,
@@ -231,7 +234,8 @@ extern "C"
         XTRACT_PERCENT,
         XTRACT_BINS,
         XTRACT_SONE,
-        XTRACT_MIDI_CENT
+        XTRACT_MIDI_CENT,
+        XTRACT_ACUM
     } xtract_unit_t;
 
     /** \brief Boolean */
@@ -323,7 +327,9 @@ extern "C"
         xtract_bool_t is_scalar;
         xtract_bool_t is_delta; /* features in xtract_delta.h can be scalar or vector */
 
-        /* some result entries in descriptors.c are unverified: see issue #150 */
+        /* a result range/unit of XTRACT_UNKNOWN_MIN/MAX or XTRACT_UNIT_UNKNOWN
+         * means the feature is unimplemented or its range is genuinely
+         * undetermined, not merely unverified */
         union {
             struct
             {

--- a/src/Make.config
+++ b/src/Make.config
@@ -25,11 +25,12 @@ STYLE_FLAGS := -Wdeclaration-after-statement -Wstrict-prototypes -Wextra -Wno-un
 .build/ooura/%.o: FLAGS := $(filter-out $(STYLE_FLAGS),$(FLAGS))
 
 # Static analysis of first-party sources (dead stores, uninitialised reads,
-# null dereferences). Requires clang; fails on any finding.
+# null dereferences, out-of-range enum casts). Requires clang; fails on any
+# finding.
 ANALYZE_SRC := $(wildcard *.c)
 analyze:
 	@output=$$(for f in $(ANALYZE_SRC); do \
-		clang --analyze -Xanalyzer -analyzer-output=text -Xanalyzer -analyzer-checker=security $(filter-out -Wconditional-uninitialized,$(FLAGS)) $$f -o /dev/null 2>&1; \
+		clang --analyze -Xanalyzer -analyzer-output=text -Xanalyzer -analyzer-checker=security -Xanalyzer -analyzer-checker=optin.core.EnumCastOutOfRange $(filter-out -Wconditional-uninitialized,$(FLAGS)) $$f -o /dev/null 2>&1; \
 	done); \
 	if [ -n "$$output" ]; then printf '%s\n' "$$output"; exit 1; fi
 	@echo "static analysis clean"

--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -157,7 +157,7 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
             *(argv_min + 1) = 0.0;
             *(argv_max + 1) = 1.0;
             *(argv_def + 1) = .1;
-            *(argv_unit + 1) = (xtract_unit_t)XTRACT_NONE;
+            *(argv_unit + 1) = XTRACT_UNIT_NONE;
             break;
         case XTRACT_NOISINESS:
         case XTRACT_SKEWNESS:
@@ -168,11 +168,11 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
             *argv_min = XTRACT_NONE;
             *argv_max = XTRACT_NONE;
             *argv_def = XTRACT_NONE;
-            *argv_unit = (xtract_unit_t)XTRACT_NONE;
+            *argv_unit = XTRACT_UNIT_NONE;
             *(argv_min + 1) = XTRACT_NONE;
             *(argv_max + 1) = XTRACT_NONE;
             *(argv_def + 1) = XTRACT_NONE;
-            *(argv_unit + 1) = (xtract_unit_t)XTRACT_NONE;
+            *(argv_unit + 1) = XTRACT_UNIT_NONE;
             break;
             /* argc = 4 */
         case XTRACT_SPECTRUM:
@@ -183,29 +183,29 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
             *(argv_min + 1) = 0;
             *(argv_max + 1) = 3;
             *(argv_def + 1) = 0;
-            *(argv_unit + 1) = (xtract_unit_t)XTRACT_NONE;
+            *(argv_unit + 1) = XTRACT_UNIT_NONE;
             *(argv_min + 2) = 0;
             *(argv_max + 2) = 1;
             *(argv_def + 2) = 0;
-            *(argv_unit + 2) = (xtract_unit_t)XTRACT_NONE;
+            *(argv_unit + 2) = XTRACT_UNIT_NONE;
             *(argv_min + 3) = 0;
             *(argv_max + 3) = 1;
             *(argv_def + 3) = 0;
-            *(argv_unit + 3) = (xtract_unit_t)XTRACT_NONE;
+            *(argv_unit + 3) = XTRACT_UNIT_NONE;
             break;
         case XTRACT_SUBBANDS:
             *argv_min = XTRACT_UNBOUNDED_MIN;
             *argv_max = XTRACT_UNBOUNDED_MAX;
             *argv_def = XTRACT_MEAN;
-            *argv_unit = (xtract_unit_t)XTRACT_NONE;
+            *argv_unit = XTRACT_UNIT_NONE;
             *(argv_min + 1) = 1;
             *(argv_max + 1) = 16384;
             *(argv_def + 1) = 4;
-            *(argv_unit + 1) = (xtract_unit_t)XTRACT_NONE;
+            *(argv_unit + 1) = XTRACT_UNIT_NONE;
             *(argv_min + 2) = 0;
             *(argv_max + 2) = 32;
             *(argv_def + 2) = 0;
-            *(argv_unit + 2) = (xtract_unit_t)XTRACT_NONE;
+            *(argv_unit + 2) = XTRACT_UNIT_NONE;
             *(argv_min + 3) = 0;
             *(argv_max + 3) = XTRACT_UNBOUNDED_MAX;
             *(argv_def + 3) = 0;
@@ -220,7 +220,7 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
             *argv_min = XTRACT_NONE;
             *argv_max = XTRACT_NONE;
             *argv_def = XTRACT_NONE;
-            *argv_unit = (xtract_unit_t)XTRACT_NONE;
+            *argv_unit = XTRACT_UNIT_NONE;
             break;
         }
 
@@ -488,7 +488,7 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
         case XTRACT_WINDOWED:
         case XTRACT_SMOOTHED:
         case XTRACT_SUBBANDS:
-            *data_unit = (xtract_unit_t)XTRACT_ANY;
+            *data_unit = XTRACT_UNIT_ANY;
             break;
         case XTRACT_SPECTRAL_MEAN:
         case XTRACT_SPECTRAL_VARIANCE:
@@ -1350,22 +1350,38 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
             case XTRACT_LNORM:
             case XTRACT_NONZERO_COUNT:
             case XTRACT_WINDOWED:
-                *result_unit = (xtract_unit_t)XTRACT_ANY;
+                *result_unit = XTRACT_UNIT_ANY;
                 *result_min = XTRACT_UNBOUNDED_MIN;
                 *result_max = XTRACT_UNBOUNDED_MAX;
                 break;
             case XTRACT_SPECTRAL_SKEWNESS:
+                /* standardised 3rd moment: any real sign and magnitude */
+                *result_unit = XTRACT_UNIT_NONE;
+                *result_min = XTRACT_UNBOUNDED_MIN;
+                *result_max = XTRACT_UNBOUNDED_MAX;
+                break;
             case XTRACT_SPECTRAL_KURTOSIS:
-            case XTRACT_IRREGULARITY_K:
-            case XTRACT_IRREGULARITY_J:
+                /* excess kurtosis (4th moment - 3): floor -2, no upper bound */
+                *result_unit = XTRACT_UNIT_NONE;
+                *result_min = -2.0;
+                *result_max = XTRACT_UNBOUNDED_MAX;
+                break;
             case XTRACT_TRISTIMULUS_1:
             case XTRACT_TRISTIMULUS_2:
             case XTRACT_TRISTIMULUS_3:
             case XTRACT_NOISINESS:
+                /* energy ratios of a partition of the total: bounded [0, 1] */
+                *result_unit = XTRACT_UNIT_NONE;
+                *result_min = 0.0;
+                *result_max = 1.0;
+                break;
+            case XTRACT_IRREGULARITY_K:
+            case XTRACT_IRREGULARITY_J:
             case XTRACT_SMOOTHNESS:
-                *result_unit = (xtract_unit_t)XTRACT_NONE;
-                *result_min = XTRACT_UNKNOWN_MIN; /* unverified result range: see issue #150 */
-                *result_max = XTRACT_UNKNOWN_MAX;
+                /* sums/ratios of non-negative deviations: >= 0, no upper bound */
+                *result_unit = XTRACT_UNIT_NONE;
+                *result_min = 0.0;
+                *result_max = XTRACT_UNBOUNDED_MAX;
                 break;
             case XTRACT_SPECTRAL_MEAN:
             case XTRACT_SPECTRAL_VARIANCE:
@@ -1394,27 +1410,54 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
                 *result_max = XTRACT_UNBOUNDED_MAX;
                 break;
             case XTRACT_ODD_EVEN_RATIO:
-                *result_unit = (xtract_unit_t)XTRACT_NONE;
+                *result_unit = XTRACT_UNIT_NONE;
                 *result_min = 0.0;
                 *result_max = 1.0;
                 break;
             case XTRACT_FLATNESS_DB:
+                /* 10*log10(flatness), flatness in (0, 1]: <= 0 dB, no true floor */
                 *result_unit = XTRACT_DBFS;
-                *result_min = XTRACT_UNKNOWN_MIN; /* unverified result range: see issue #150 */
-                *result_max = XTRACT_UNKNOWN_MAX;
+                *result_min = XTRACT_UNBOUNDED_MIN;
+                *result_max = 0.0;
                 break;
             case XTRACT_LOUDNESS:
+                /* sum of specific loudnesses (band energy^0.23): >= 0, in sones */
+                *result_unit = XTRACT_SONE;
+                *result_min = 0.0;
+                *result_max = XTRACT_UNBOUNDED_MAX;
+                break;
             case XTRACT_FLATNESS:
+                /* geometric mean / arithmetic mean (Wiener entropy): [0, 1] */
             case XTRACT_TONALITY:
-            case XTRACT_CREST:
+                /* min(flatness_db / -60, 1): [0, 1] */
             case XTRACT_SPECTRAL_INHARMONICITY:
-            case XTRACT_POWER:
+                /* amplitude-weighted mean of normalised detunings: [0, 1] */
+                *result_unit = XTRACT_UNIT_NONE;
+                *result_min = 0.0;
+                *result_max = 1.0;
+                break;
+            case XTRACT_CREST:
+                /* max / mean of non-negative data: >= 1, no upper bound */
+                *result_unit = XTRACT_UNIT_NONE;
+                *result_min = 1.0;
+                *result_max = XTRACT_UNBOUNDED_MAX;
+                break;
             case XTRACT_SHARPNESS:
+                /* loudness-weighted Bark centroid: >= 0, in acums */
+                *result_unit = XTRACT_ACUM;
+                *result_min = 0.0;
+                *result_max = XTRACT_UNBOUNDED_MAX;
+                break;
             case XTRACT_SPECTRAL_SLOPE:
-            case XTRACT_LPC:
-            case XTRACT_LPCC:
+                /* least-squares regression slope: any real sign and magnitude */
+                *result_unit = XTRACT_UNIT_NONE;
+                *result_min = XTRACT_UNBOUNDED_MIN;
+                *result_max = XTRACT_UNBOUNDED_MAX;
+                break;
+            case XTRACT_POWER:
+                /* unimplemented (returns XTRACT_FEATURE_NOT_IMPLEMENTED) */
             default:
-                *result_unit = (xtract_unit_t)XTRACT_UNKNOWN;
+                *result_unit = XTRACT_UNIT_UNKNOWN;
                 *result_min = XTRACT_UNKNOWN_MIN;
                 *result_max = XTRACT_UNKNOWN_MAX;
                 break;
@@ -1437,11 +1480,12 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
             case XTRACT_WINDOWED:
             case XTRACT_SMOOTHED:
                 *result_format = XTRACT_ARBITRARY_SERIES;
-                *result_unit = (xtract_unit_t)XTRACT_ANY;
+                *result_unit = XTRACT_UNIT_ANY;
                 break;
             case XTRACT_BARK_COEFFICIENTS:
+                /* per-band sums on a Bark-band (not Hz) axis: dimensionless */
                 *result_format = XTRACT_BARK_COEFFS;
-                *result_unit = (xtract_unit_t)XTRACT_UNKNOWN; /* unverified result unit: see issue #150 */
+                *result_unit = XTRACT_UNIT_NONE;
                 break;
             case XTRACT_PEAK_SPECTRUM:
             case XTRACT_SPECTRUM:
@@ -1452,28 +1496,32 @@ xtract_function_descriptor_t *xtract_make_descriptors(void)
             case XTRACT_AUTOCORRELATION_FFT:
                 break;
             case XTRACT_MFCC:
+                /* DCT of log filterbank energies: dimensionless cepstral coeffs */
                 *result_format = XTRACT_MEL_COEFFS;
-                *result_unit = (xtract_unit_t)XTRACT_UNKNOWN; /* unverified result unit: see issue #150 */
+                *result_unit = XTRACT_UNIT_NONE;
                 break;
             case XTRACT_MEL_SPECTROGRAM:
                 *result_format = XTRACT_MEL_COEFFS;
                 *result_unit = XTRACT_DBFS;
                 break;
             case XTRACT_GFCC:
+                /* DCT of log gammatone energies: dimensionless cepstral coeffs */
                 *result_format = XTRACT_MEL_COEFFS;
-                *result_unit = (xtract_unit_t)XTRACT_UNKNOWN;
+                *result_unit = XTRACT_UNIT_NONE;
                 break;
             case XTRACT_GAMMATONE_SPECTROGRAM:
                 *result_format = XTRACT_MEL_COEFFS;
                 *result_unit = XTRACT_DBFS;
                 break;
             case XTRACT_LPC:
+                /* predictor/reflection coefficients: dimensionless */
                 *result_format = XTRACT_LPC_COEFFS;
-                *result_unit = (xtract_unit_t)XTRACT_UNKNOWN;
+                *result_unit = XTRACT_UNIT_NONE;
                 break;
             case XTRACT_LPCC:
+                /* cepstral coefficients: dimensionless */
                 *result_format = XTRACT_LPCC_COEFFS;
-                *result_unit = (xtract_unit_t)XTRACT_UNKNOWN;
+                *result_unit = XTRACT_UNIT_NONE;
                 break;
             default:
                 break;

--- a/tests/xttest_descriptors.c
+++ b/tests/xttest_descriptors.c
@@ -38,6 +38,60 @@ UTEST(descriptors, free_descriptors_accepts_null)
     ASSERT_EQ(xtract_free_descriptors(NULL), XTRACT_SUCCESS);
 }
 
+UTEST(descriptors, unit_sentinels_have_expected_values)
+{
+    /* The NONE/ANY/UNKNOWN unit members carry the sentinel values the
+     * descriptor metadata relies on; the dimensioned units stay >= 2. */
+    ASSERT_EQ((int)XTRACT_UNIT_UNKNOWN, -2);
+    ASSERT_EQ((int)XTRACT_UNIT_ANY, -1);
+    ASSERT_EQ((int)XTRACT_UNIT_NONE, 0);
+    ASSERT_EQ((int)XTRACT_HERTZ, 2);
+}
+
+UTEST(descriptors, scalar_result_ranges_are_ordered)
+{
+    /* No scalar feature should advertise a result_min above its result_max. */
+    xtract_function_descriptor_t *fd = xtract_make_descriptors();
+    int f;
+    ASSERT_TRUE(fd != NULL);
+    for (f = 0; f < XTRACT_FEATURES; f++)
+        if (fd[f].is_scalar)
+            ASSERT_LE(fd[f].result.scalar.min, fd[f].result.scalar.max);
+    ASSERT_EQ(xtract_free_descriptors(fd), XTRACT_SUCCESS);
+}
+
+UTEST(descriptors, audited_result_ranges_and_units)
+{
+    /* Representative features from the issue #150 range/unit audit. */
+    xtract_function_descriptor_t *fd = xtract_make_descriptors();
+    ASSERT_TRUE(fd != NULL);
+
+    /* Tristimulus is an energy ratio in [0, 1], dimensionless. */
+    CHECK_REL(fd[XTRACT_TRISTIMULUS_1].result.scalar.min, 0.0, EPSILON);
+    CHECK_REL(fd[XTRACT_TRISTIMULUS_1].result.scalar.max, 1.0, EPSILON);
+    ASSERT_EQ(fd[XTRACT_TRISTIMULUS_1].result.scalar.unit, XTRACT_UNIT_NONE);
+
+    /* Excess kurtosis is floored at -2. */
+    CHECK_REL(fd[XTRACT_SPECTRAL_KURTOSIS].result.scalar.min, -2.0, EPSILON);
+
+    /* Crest factor max/mean is >= 1. */
+    CHECK_REL(fd[XTRACT_CREST].result.scalar.min, 1.0, EPSILON);
+
+    /* Flatness in dB is <= 0 with no true floor. */
+    CHECK_REL(fd[XTRACT_FLATNESS_DB].result.scalar.max, 0.0, EPSILON);
+    ASSERT_EQ(fd[XTRACT_FLATNESS_DB].result.scalar.unit, XTRACT_DBFS);
+
+    /* Loudness is in sones, sharpness in acums. */
+    ASSERT_EQ(fd[XTRACT_LOUDNESS].result.scalar.unit, XTRACT_SONE);
+    ASSERT_EQ(fd[XTRACT_SHARPNESS].result.scalar.unit, XTRACT_ACUM);
+
+    /* Cepstral/LPC coefficient vectors are dimensionless. */
+    ASSERT_EQ(fd[XTRACT_LPCC].result.vector.unit, XTRACT_UNIT_NONE);
+    ASSERT_EQ(fd[XTRACT_BARK_COEFFICIENTS].result.vector.unit, XTRACT_UNIT_NONE);
+
+    ASSERT_EQ(xtract_free_descriptors(fd), XTRACT_SUCCESS);
+}
+
 UTEST(dispatch, every_feature_slot_points_to_a_function)
 {
     int f;


### PR DESCRIPTION
Closes #150.

### Result range/unit audit
Every descriptor result entry that previously held a placeholder `XTRACT_UNKNOWN_MIN/MAX` or `XTRACT_UNIT_UNKNOWN` now carries a value derived from the feature's actual computation (each annotated with the formula basis):

| Bound type | Features |
|---|---|
| `[0, 1]`, dimensionless | tristimulus 1/2/3, noisiness, flatness, tonality, spectral inharmonicity |
| floored | spectral kurtosis ≥ -2 (excess), crest ≥ 1 |
| `[0, ∞)`, non-negative | irregularity k/j, smoothness, loudness (sones), sharpness (acums) |
| `(-∞, ∞)` | spectral skewness, spectral slope, LPC/LPCC coefficients |
| `(-∞, 0]` dB | flatness_db |
| dimensionless vectors | LPC, LPCC, MFCC, GFCC, bark coefficients |

`XTRACT_POWER` stays `UNKNOWN` because it is unimplemented (returns `XTRACT_FEATURE_NOT_IMPLEMENTED`). The mis-placed *scalar* `LPC`/`LPCC` cases are dropped — both are vector features already handled in the vector branch.

### Unit enum members + analyzer guard
The metadata stored the sentinels `-1`, `0`, `-2` into `xtract_unit_t` via casts to values outside the enumeration (the surviving sibling of the #135 ambiguous-sentinel pattern). This adds explicit `XTRACT_UNIT_NONE (0)`, `XTRACT_UNIT_ANY (-1)`, `XTRACT_UNIT_UNKNOWN (-2)` members (value-preserving — the dimensioned units keep their `>= 2` values for ABI stability) plus `XTRACT_ACUM` for sharpness, and replaces every `(xtract_unit_t)XTRACT_*` cast with the new members.

With the casts legitimate, `make analyze` now also runs clang's `optin.core.EnumCastOutOfRange` checker as a regression guard.

### Tests
Adds descriptor tests pinning representative ranges/units, the unit sentinel values, and a `result_min <= result_max` invariant across all scalar features.

`make`, `make check` (245 tests), `make analyze` (incl. the new enum checker) and `make format-check` all pass locally.